### PR TITLE
Issue5-1 リアルタイムに現在時刻（時分秒）を表示する

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "33.0.0"
     defaultConfig {
         applicationId "com.example.zaikokanri"
-        minSdkVersion 15
+        minSdkVersion 17
         targetSdkVersion 33
         versionCode 1
         versionName "1.0"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -68,6 +68,7 @@
         android:layout_height="45dp"
         android:textSize="35sp"
         android:format24Hour="HH:mm:ss"
+        android:textColor="#808080"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/textView1" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -21,6 +21,7 @@
         android:layout_height="45dp"
         android:text="@string/zero"
         android:textSize="35sp"
+        app:layout_constraintBottom_toTopOf="@id/clock"
         app:layout_constraintStart_toEndOf="@+id/textView1"
         app:layout_constraintTop_toTopOf="parent" />
 
@@ -40,15 +41,6 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <TextView
-        android:id="@+id/clock"
-        android:layout_width="140dp"
-        android:layout_height="45dp"
-        android:text="@string/clock"
-        android:textSize="35sp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/number" />
-
     <EditText
         android:id="@+id/comment"
         android:layout_width="130dp"
@@ -56,6 +48,9 @@
         android:ems="10"
         android:inputType="textPersonName"
         android:text="@string/comment"
+        android:autofillHints=""
+        tools:targetApi="26"
+        android:hint="@string/comment"
         app:layout_constraintStart_toEndOf="@+id/clock"
         app:layout_constraintTop_toBottomOf="@+id/plusButton" />
 
@@ -67,4 +62,12 @@
         app:layout_constraintStart_toEndOf="@+id/comment"
         app:layout_constraintTop_toBottomOf="@+id/plusButton" />
 
+    <TextClock
+        android:id="@+id/clock"
+        android:layout_width="140dp"
+        android:layout_height="45dp"
+        android:textSize="35sp"
+        android:format24Hour="HH:mm:ss"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textView1" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## チケットURL
https://github.com/freemake-morikawa/zaikokanri/pull/12

## 対応内容・対応背景・妥協点
- リアルタイムに現在時刻（時分秒）を表示する

## やったこと
- TextClockタグを使用して時計機能実装
	- それに伴ってTextViewタグを削除
- 24時間表示の形式を指定（HH:mm:ss)
- TextClockタグを利用するために最小バージョンをあげる必要があったので変更
	- minSdkVersionを15→17へ変更
	- APIレベル17はAndroid4.2の2013年とかなり前のバージョンなので、変更してもよいと判断

## やっていないこと
- 端末の時間形式に左右されるため、端末が12時間表示の際に12時間表示になってしまう
	- こちらの対応方法は調べたがわからなかったため対応せず(涙)

## UI before/after
- before > 00:00:00固定
- after
https://user-images.githubusercontent.com/115610835/196092209-09366d17-c4a5-4450-9891-746748ec2ff9.mp4

## テスト
- 必要項目が思いつかなかったため実施せず