### PR TITLE
Issue5-2 

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/com/example/zaikokanri/MainActivity.java
+++ b/app/src/main/java/com/example/zaikokanri/MainActivity.java
@@ -17,19 +17,13 @@ import java.util.Timer;
 import java.util.TimerTask;
 
 import android.os.Handler;
-import android.os.Build;
-
-import androidx.annotation.RequiresApi;
 
 public class MainActivity extends AppCompatActivity {
-
-
     int count = 0;
     TextView textView;
     Button plusButton;
     Button minusButton;
     TextView clock;
-    Handler myHandler = new Handler();
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -86,7 +80,6 @@ public class MainActivity extends AppCompatActivity {
         DecimalFormat decFormat = new DecimalFormat("#,###");
         return decFormat.format(num);
     }
-
 
     // Timerで呼び出すタスクを作成
     public class MainTimerTask extends TimerTask {

--- a/app/src/main/java/com/example/zaikokanri/MainActivity.java
+++ b/app/src/main/java/com/example/zaikokanri/MainActivity.java
@@ -93,6 +93,7 @@ public class MainActivity extends AppCompatActivity {
     protected void onStop() {
         super.onStop();
         myTimer.cancel();
+        Log.v("Test", "アプリがバックグラウンドに移行しました");
     }
     @Override
     protected void onStart() {
@@ -102,6 +103,7 @@ public class MainActivity extends AppCompatActivity {
         // タスクを作成
         myTimerTask = new MainTimerTask();
         myTimer.schedule(myTimerTask, 0, 100);
+        Log.v("Test", "アプリがフォアグラウンドに移行しました");
     }
 
 }

--- a/app/src/main/java/com/example/zaikokanri/MainActivity.java
+++ b/app/src/main/java/com/example/zaikokanri/MainActivity.java
@@ -16,8 +16,6 @@ import java.util.Date;
 import java.util.Timer;
 import java.util.TimerTask;
 
-import android.os.Handler;
-
 public class MainActivity extends AppCompatActivity {
     int count = 0;
     TextView textView;

--- a/app/src/main/java/com/example/zaikokanri/MainActivity.java
+++ b/app/src/main/java/com/example/zaikokanri/MainActivity.java
@@ -4,17 +4,18 @@ import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 
 import android.os.Bundle;
-
 import android.view.View;
 import android.widget.TextView;
 import android.widget.Button;
 
 import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
-
 import java.util.Date;
 import java.util.Timer;
 import java.util.TimerTask;
+
+// Debug
+import android.util.Log;
 
 public class MainActivity extends AppCompatActivity {
     int count = 0;
@@ -22,6 +23,8 @@ public class MainActivity extends AppCompatActivity {
     Button plusButton;
     Button minusButton;
     TextView clock;
+    Timer myTimer;
+    MainTimerTask myTimerTask;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -63,14 +66,9 @@ public class MainActivity extends AppCompatActivity {
         });
 
         // ここから下は時計機能
-        Timer myTimer = new Timer();
         clock = findViewById(R.id.clock);
 
-        // タスクを作成
-        MainTimerTask myTimerTask = new MainTimerTask();
 
-        // 100ミリ秒に１回タスクを実行する
-        myTimer.schedule(myTimerTask, 0, 100);
     }
 
     // 3桁ごとにカンマを入れて返します
@@ -84,7 +82,26 @@ public class MainActivity extends AppCompatActivity {
         @Override
         public void run(){
             clock.setText((new SimpleDateFormat("HH:mm:ss")).format(new Date()));
+
+            // /* Debug
+            Log.v("Test",(new SimpleDateFormat("HH:mm:ss")).format(new Date()));
+            // */
         }
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        myTimer.cancel();
+    }
+    @Override
+    protected void onStart() {
+        super.onStart();
+        // 100ミリ秒に１回タスクを実行する
+        myTimer = new Timer();
+        // タスクを作成
+        myTimerTask = new MainTimerTask();
+        myTimer.schedule(myTimerTask, 0, 100);
     }
 
 }


### PR DESCRIPTION
## チケットURL
https://github.com/freemake-morikawa/zaikokanri/pull/14

## 対応内容・対応背景・妥協点
- アプリがバックグラウンド移行時に停止する
- アプリが再表示時に再開する

## やったこと
- onStartとonStopをOverrideしてアプリ起動時、バックグラウンド移行時、アプリ再開時にタスクを開始させるように改修
- Android Appでのライフサイクルを理解

## やっていないこと

## UI:before/after
- before(バックグラウンド移行後も処理が続く）
https://user-images.githubusercontent.com/115610835/197102054-edb25dc3-5764-4b8b-bd38-4d49ca91d992.mp4

- after
https://user-images.githubusercontent.com/115610835/197102386-1e972c7a-eed8-4325-8589-b9a58cae8f78.mp4


## テスト
- Logcatを利用し、時間が更新されていることを常に表示する
- バックグラウンド移行時にログを吐く
- フォアグラウンド移行時にログを吐く
- バックグラウンドにいる際にはログ上で処理が止まっていることを確認