### PR TITLE
Issue6-4　 背景色は、選択済み、奇数行、偶数行で色分けする

### DIFF
--- a/app/src/main/java/com/example/zaikokanri/MainActivity.java
+++ b/app/src/main/java/com/example/zaikokanri/MainActivity.java
@@ -1,19 +1,19 @@
 package com.example.zaikokanri;
 
 import android.content.Context;
-import android.graphics.Color;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
+import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.ListView;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
-import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 
 import java.text.DecimalFormat;
@@ -25,120 +25,116 @@ import java.util.Timer;
 import java.util.TimerTask;
 
 public class MainActivity extends AppCompatActivity {
-    int count = 0;
-    TextView textView;
-    Button plusButton;
-    Button minusButton;
-    Button addButton;
-    TextView clock;
-    Timer myTimer;
-    MainTimerTask myTimerTask;
-    List<CellData> list = new ArrayList<>();
+
+    List<CellData> list;
+    private int count;
+    private TextView clockText;
+    private ListView listView;
+
+    private Timer timer;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        ActionBar actionBar = getSupportActionBar();
-        if (actionBar != null) {
-            actionBar.setTitle("Freemake");
-        }
+        // 初期化
+        count = 0;
+        list = new ArrayList<>();
 
-        textView = findViewById(R.id.number);
-        plusButton = findViewById(R.id.plusButton);
-        minusButton = findViewById(R.id.minusButton);
-        addButton = findViewById(R.id.add);
+        // アクションバーの変更
+        getSupportActionBar().setTitle("Freemake");
 
-        // 加算
+        // Viewの取得
+        final TextView countText = findViewById(R.id.count);
+        final Button plusButton = findViewById(R.id.plusButton);
+        final Button minusButton = findViewById(R.id.minusButton);
+        final Button addButton = findViewById(R.id.addButton);
+
+        clockText = findViewById(R.id.clock);
+        listView = findViewById(R.id.list);
+
+        // 加算・減算
         plusButton.setOnClickListener(new View.OnClickListener() {
+            @Override
             public void onClick(View v) {
                 count++;
                 if (count > 9999) {
                     count = 9999;
                 }
-                textView.setText(formatThousand(count));
+                countText.setText(formatThousand(count));
             }
         });
-
-        // 減算
         minusButton.setOnClickListener(new View.OnClickListener() {
+            @Override
             public void onClick(View v) {
                 count--;
                 if (count < 0) {
                     count = 0;
                 }
-                textView.setText(formatThousand(count));
+                countText.setText(formatThousand(count));
             }
         });
 
-        // ここから下は時計機能
-        clock = findViewById(R.id.clock);
-
-        // リスト
+        // リスト追加
         addButton.setOnClickListener(new View.OnClickListener() {
+            @Override
             public void onClick(View v) {
                 addStringData(list);
             }
         });
     }
 
+    // リスト追加処理
     private void addStringData(List<CellData> list) {
         TextView time = findViewById(R.id.clock);
-        TextView number = findViewById(R.id.number);
+        TextView count = findViewById(R.id.count);
         EditText comment = findViewById(R.id.comment);
         ListView listView = findViewById(R.id.list);
 
-        CellData data = new CellData(time.getText().toString(), number.getText().toString(), comment.getText().toString());
+        CellData data = new CellData(time.getText().toString(), count.getText().toString(), comment.getText().toString());
         list.add(data);
 
         listView.setAdapter(new ListViewAdapter(this, R.layout.list, list));
     }
 
-    // 3桁ごとにカンマを入れて返します
-    private String formatThousand(int num) {
-        DecimalFormat decFormat = new DecimalFormat("#,###");
-        return decFormat.format(num);
+    @Override
+    protected void onStart() {
+        super.onStart();
+        timer = new Timer();
+        timer.schedule(new MainTimerTask(), 0, 100);
     }
 
     @Override
     protected void onStop() {
         super.onStop();
-        myTimer.cancel();
+        timer.cancel();
     }
 
-    @Override
-    protected void onStart() {
-        super.onStart();
-        // 100ミリ秒に１回タスクを実行する
-        myTimer = new Timer();
-        // タスクを作成
-        myTimerTask = new MainTimerTask();
-        myTimer.schedule(myTimerTask, 0, 100);
+    // 3桁ごとにカンマ挿入
+    private String formatThousand(int num) {
+        DecimalFormat df = new DecimalFormat("#,###");
+        return df.format(num);
     }
 
-    // itemのデータを保持するクラス
-    class CellData {
+    // データを保持するクラス
+    private class CellData {
+        boolean check;
         String time;
-        String number;
+        String count;
         String comment;
 
-        CellData(String time, String number, String comment) {
+        CellData(String time, String count, String comment) {
+            this.check = false;
             this.time = time;
-            this.number = number;
+            this.count = count;
             this.comment = comment;
         }
     }
 
-    class ViewHolder {
-        TextView viewTime;
-        TextView viewNumber;
-        TextView viewComment;
-    }
-
-    // ArrayAdapterを継承したカスタムのアダプタークラス
-    class ListViewAdapter extends ArrayAdapter<CellData> {
-        CellData data;
+    // カスタムアダプタークラス
+    private class ListViewAdapter extends ArrayAdapter<CellData> {
+        private CellData data;
         private LayoutInflater inflater;
         private int itemLayout;
 
@@ -150,39 +146,44 @@ public class MainActivity extends AppCompatActivity {
 
         @Override
         public @NonNull
-        View getView(int position, View convertView, @NonNull ViewGroup parent) {
+        View getView(final int position, View convertView, @NonNull ViewGroup parent) {
             ViewHolder holder;
+            Log.i("Test", "positionは" + position + "です");
             if (convertView == null) {
                 convertView = inflater.inflate(itemLayout, parent, false);
                 holder = new ViewHolder();
+                holder.viewCheck = convertView.findViewById(R.id.listCheckBox);
                 holder.viewTime = convertView.findViewById(R.id.listTime);
-                holder.viewNumber = convertView.findViewById(R.id.listNumber);
+                holder.viewCount = convertView.findViewById(R.id.listCount);
                 holder.viewComment = convertView.findViewById(R.id.listComment);
                 convertView.setTag(holder);
 
-                // 偶数行の色を変更
-                if (position % 2 == 0) {
-                    convertView.setBackgroundColor(Color.rgb(100, 149, 237));
-                }
             } else {
                 holder = (ViewHolder) convertView.getTag();
             }
-
             data = getItem(position);
             if (data != null) {
                 holder.viewTime.setText(data.time);
-                holder.viewNumber.setText(data.number);
+                holder.viewCount.setText(data.count);
                 holder.viewComment.setText(data.comment);
             }
             return convertView;
         }
+
+        // Viewを保持するクラス
+        private class ViewHolder {
+            CheckBox viewCheck;
+            TextView viewTime;
+            TextView viewCount;
+            TextView viewComment;
+        }
     }
 
-    // Timerで呼び出すタスクを作成
+    // Timerで呼び出すタスクのクラス
     public class MainTimerTask extends TimerTask {
         @Override
         public void run() {
-            clock.setText((new SimpleDateFormat("HH:mm:ss")).format(new Date()));
+            clockText.setText((new SimpleDateFormat("HH:mm:ss")).format(new Date()));
         }
     }
 }

--- a/app/src/main/java/com/example/zaikokanri/MainActivity.java
+++ b/app/src/main/java/com/example/zaikokanri/MainActivity.java
@@ -1,6 +1,7 @@
 package com.example.zaikokanri;
 
 import android.content.Context;
+import android.graphics.Color;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -82,7 +83,6 @@ public class MainActivity extends AppCompatActivity {
         });
     }
 
-    //
     private void addStringData(List<CellData> list) {
         TextView time = findViewById(R.id.clock);
         TextView number = findViewById(R.id.number);
@@ -159,6 +159,11 @@ public class MainActivity extends AppCompatActivity {
                 holder.viewNumber = convertView.findViewById(R.id.listNumber);
                 holder.viewComment = convertView.findViewById(R.id.listComment);
                 convertView.setTag(holder);
+
+                // 偶数行の色を変更
+                if (position % 2 == 0) {
+                    convertView.setBackgroundColor(Color.rgb(100, 149, 237));
+                }
             } else {
                 holder = (ViewHolder) convertView.getTag();
             }

--- a/app/src/main/java/com/example/zaikokanri/MainActivity.java
+++ b/app/src/main/java/com/example/zaikokanri/MainActivity.java
@@ -33,7 +33,6 @@ public class MainActivity extends AppCompatActivity {
     Timer myTimer;
     MainTimerTask myTimerTask;
     List<CellData> list = new ArrayList<>();
-    ListViewAdapter adapter;
 
     // itemのデータを保持するクラス
     class CellData {
@@ -91,12 +90,13 @@ public class MainActivity extends AppCompatActivity {
         // リスト
         addButton.setOnClickListener(new View.OnClickListener() {
           public void onClick(View v) {
-              addStringData(list, adapter);
+              addStringData(list);
           }
         });
     }
 
-    private void addStringData(List<CellData> list, ListViewAdapter adapter) {
+    // 
+    private void addStringData(List<CellData> list) {
         TextView time = findViewById(R.id.clock);
         TextView number = findViewById(R.id.number);
         EditText comment = findViewById(R.id.comment);
@@ -105,8 +105,7 @@ public class MainActivity extends AppCompatActivity {
         CellData data = new CellData(time.getText().toString(), number.getText().toString(), comment.getText().toString());
         list.add(data);
 
-        adapter = new ListViewAdapter(this, R.layout.list, list);
-        listView.setAdapter(adapter);
+        listView.setAdapter(new ListViewAdapter(this, R.layout.list, list));
     }
 
     class ViewHolder {

--- a/app/src/main/java/com/example/zaikokanri/MainActivity.java
+++ b/app/src/main/java/com/example/zaikokanri/MainActivity.java
@@ -1,27 +1,27 @@
 package com.example.zaikokanri;
 
+import android.content.Context;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.ListView;
+import android.widget.TextView;
+
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 
-import android.view.ViewGroup;
-import android.widget.ListView;
-import android.content.Context;
-import android.os.Bundle;
-import android.view.View;
-import android.view.LayoutInflater;
-import android.widget.ArrayAdapter;
-import android.widget.TextView;
-import android.widget.Button;
-import android.widget.EditText;
-
 import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.Timer;
 import java.util.TimerTask;
-import java.util.ArrayList;
-import java.util.List;
 
 public class MainActivity extends AppCompatActivity {
     int count = 0;
@@ -33,19 +33,6 @@ public class MainActivity extends AppCompatActivity {
     Timer myTimer;
     MainTimerTask myTimerTask;
     List<CellData> list = new ArrayList<>();
-
-    // itemのデータを保持するクラス
-    class CellData {
-        String time;
-        String number;
-        String comment;
-
-        CellData(String time, String number, String comment) {
-            this.time = time;
-            this.number = number;
-            this.comment = comment;
-        }
-    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -66,7 +53,7 @@ public class MainActivity extends AppCompatActivity {
         plusButton.setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
                 count++;
-                if(count > 9999) {
+                if (count > 9999) {
                     count = 9999;
                 }
                 textView.setText(formatThousand(count));
@@ -77,7 +64,7 @@ public class MainActivity extends AppCompatActivity {
         minusButton.setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
                 count--;
-                if(count < 0){
+                if (count < 0) {
                     count = 0;
                 }
                 textView.setText(formatThousand(count));
@@ -89,13 +76,13 @@ public class MainActivity extends AppCompatActivity {
 
         // リスト
         addButton.setOnClickListener(new View.OnClickListener() {
-          public void onClick(View v) {
-              addStringData(list);
-          }
+            public void onClick(View v) {
+                addStringData(list);
+            }
         });
     }
 
-    // 
+    //
     private void addStringData(List<CellData> list) {
         TextView time = findViewById(R.id.clock);
         TextView number = findViewById(R.id.number);
@@ -108,60 +95,10 @@ public class MainActivity extends AppCompatActivity {
         listView.setAdapter(new ListViewAdapter(this, R.layout.list, list));
     }
 
-    class ViewHolder {
-        TextView viewTime;
-        TextView viewNumber;
-        TextView viewComment;
-    }
-
-    // ArrayAdapterを継承したカスタムのアダプタークラス
-    class ListViewAdapter extends ArrayAdapter<CellData> {
-        private LayoutInflater inflater;
-        private int itemLayout;
-        CellData data;
-
-        ListViewAdapter(Context context, int itemLayout, List<CellData> list) {
-            super(context, 0, list);
-            this.inflater = (LayoutInflater)context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
-            this.itemLayout = itemLayout;
-        }
-
-        @Override
-        public @NonNull View getView(int position, View convertView, @NonNull ViewGroup parent) {
-            ViewHolder holder;
-            if(convertView==null) {
-                convertView = inflater.inflate(itemLayout, parent, false);
-                holder = new ViewHolder();
-                holder.viewTime = convertView.findViewById(R.id.listTime);
-                holder.viewNumber = convertView.findViewById(R.id.listNumber);
-                holder.viewComment = convertView.findViewById(R.id.listComment);
-                convertView.setTag(holder);
-            } else {
-              holder = (ViewHolder)convertView.getTag();
-            }
-
-            data = getItem(position);
-            if(data != null) {
-                holder.viewTime.setText(data.time);
-                holder.viewNumber.setText(data.number);
-                holder.viewComment.setText(data.comment);
-            }
-            return convertView;
-        }
-    }
-
     // 3桁ごとにカンマを入れて返します
     private String formatThousand(int num) {
         DecimalFormat decFormat = new DecimalFormat("#,###");
         return decFormat.format(num);
-    }
-
-    // Timerで呼び出すタスクを作成
-    public class MainTimerTask extends TimerTask {
-        @Override
-        public void run(){
-            clock.setText((new SimpleDateFormat("HH:mm:ss")).format(new Date()));
-        }
     }
 
     @Override
@@ -169,6 +106,7 @@ public class MainActivity extends AppCompatActivity {
         super.onStop();
         myTimer.cancel();
     }
+
     @Override
     protected void onStart() {
         super.onStart();
@@ -178,4 +116,68 @@ public class MainActivity extends AppCompatActivity {
         myTimerTask = new MainTimerTask();
         myTimer.schedule(myTimerTask, 0, 100);
     }
- }
+
+    // itemのデータを保持するクラス
+    class CellData {
+        String time;
+        String number;
+        String comment;
+
+        CellData(String time, String number, String comment) {
+            this.time = time;
+            this.number = number;
+            this.comment = comment;
+        }
+    }
+
+    class ViewHolder {
+        TextView viewTime;
+        TextView viewNumber;
+        TextView viewComment;
+    }
+
+    // ArrayAdapterを継承したカスタムのアダプタークラス
+    class ListViewAdapter extends ArrayAdapter<CellData> {
+        CellData data;
+        private LayoutInflater inflater;
+        private int itemLayout;
+
+        ListViewAdapter(Context context, int itemLayout, List<CellData> list) {
+            super(context, 0, list);
+            this.inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+            this.itemLayout = itemLayout;
+        }
+
+        @Override
+        public @NonNull
+        View getView(int position, View convertView, @NonNull ViewGroup parent) {
+            ViewHolder holder;
+            if (convertView == null) {
+                convertView = inflater.inflate(itemLayout, parent, false);
+                holder = new ViewHolder();
+                holder.viewTime = convertView.findViewById(R.id.listTime);
+                holder.viewNumber = convertView.findViewById(R.id.listNumber);
+                holder.viewComment = convertView.findViewById(R.id.listComment);
+                convertView.setTag(holder);
+            } else {
+                holder = (ViewHolder) convertView.getTag();
+            }
+
+            data = getItem(position);
+            if (data != null) {
+                holder.viewTime.setText(data.time);
+                holder.viewNumber.setText(data.number);
+                holder.viewComment.setText(data.comment);
+            }
+            return convertView;
+        }
+    }
+
+    // Timerで呼び出すタスクを作成
+    public class MainTimerTask extends TimerTask {
+        @Override
+        public void run() {
+            clock.setText((new SimpleDateFormat("HH:mm:ss")).format(new Date()));
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -16,7 +16,7 @@ tools:context=".MainActivity">
     app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
-        android:id="@+id/number"
+        android:id="@+id/count"
         android:layout_width="130dp"
         android:layout_height="45dp"
         android:text="@string/zero"
@@ -55,7 +55,7 @@ tools:context=".MainActivity">
         app:layout_constraintTop_toBottomOf="@+id/plusButton" />
 
     <Button
-        android:id="@+id/add"
+        android:id="@+id/addButton"
         android:layout_width="wrap_content"
         android:layout_height="45dp"
         android:text="@string/add"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -7,34 +7,34 @@ android:layout_height="match_parent"
 tools:context=".MainActivity">
 
     <TextView
-    android:id="@+id/textView1"
+    android:id="@+id/quantity"
     android:layout_width="75dp"
     android:layout_height="45dp"
-    android:text="@string/suuryo"
+    android:text="@string/quantity"
     android:textSize="35sp"
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toTopOf="parent" />
 
+    <Button
+        android:id="@+id/plus_button"
+        android:layout_width="wrap_content"
+        android:layout_height="45dp"
+        android:text="@string/plus"
+        app:layout_constraintEnd_toStartOf="@+id/minus_button"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <TextView
-        android:id="@+id/count"
+        android:id="@+id/count_text"
         android:layout_width="130dp"
         android:layout_height="45dp"
         android:text="@string/zero"
         android:textSize="35sp"
-        app:layout_constraintBottom_toTopOf="@id/clock"
-        app:layout_constraintStart_toEndOf="@+id/textView1"
+        app:layout_constraintBottom_toTopOf="@id/clock_text"
+        app:layout_constraintStart_toEndOf="@+id/quantity"
         app:layout_constraintTop_toTopOf="parent" />
 
     <Button
-        android:id="@+id/plusButton"
-        android:layout_width="wrap_content"
-        android:layout_height="45dp"
-        android:text="@string/plus"
-        app:layout_constraintEnd_toStartOf="@+id/minusButton"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    <Button
-        android:id="@+id/minusButton"
+        android:id="@+id/minus_button"
         android:layout_width="wrap_content"
         android:layout_height="45dp"
         android:text="@string/minus"
@@ -42,7 +42,7 @@ tools:context=".MainActivity">
         app:layout_constraintTop_toTopOf="parent" />
 
     <EditText
-        android:id="@+id/comment"
+        android:id="@+id/comment_text"
         android:layout_width="130dp"
         android:layout_height="45dp"
         android:ems="10"
@@ -51,32 +51,32 @@ tools:context=".MainActivity">
         android:autofillHints=""
         tools:targetApi="26"
         android:hint="@string/comment"
-        app:layout_constraintStart_toEndOf="@+id/clock"
-        app:layout_constraintTop_toBottomOf="@+id/plusButton" />
+        app:layout_constraintStart_toEndOf="@+id/clock_text"
+        app:layout_constraintTop_toBottomOf="@+id/plus_button" />
 
     <Button
-        android:id="@+id/addButton"
+        android:id="@+id/add_button"
         android:layout_width="wrap_content"
         android:layout_height="45dp"
         android:text="@string/add"
-        app:layout_constraintStart_toEndOf="@+id/comment"
-        app:layout_constraintTop_toBottomOf="@+id/plusButton" />
+        app:layout_constraintStart_toEndOf="@+id/comment_text"
+        app:layout_constraintTop_toBottomOf="@+id/plus_button" />
 
     <TextView
-        android:id="@+id/clock"
+        android:id="@+id/clock_text"
         android:layout_width="140dp"
         android:layout_height="45dp"
         android:textSize="35sp"
         android:format24Hour="HH:mm:ss"
         android:textColor="#808080"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/textView1" />
+        app:layout_constraintTop_toBottomOf="@+id/quantity" />
 
     <ListView
-        android:id="@+id/list"
+        android:id="@+id/list_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@+id/comment"
+        app:layout_constraintTop_toBottomOf="@+id/comment_text"
         tools:layout_editor_absoluteX="131dp" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/list.xml
+++ b/app/src/main/res/layout/list.xml
@@ -1,36 +1,40 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="horizontal">
 
     <CheckBox
         android:id="@+id/listCheckBox"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content" />
+        android:layout_width="30dp"
+        android:layout_height="fill_parent" />
 
     <TextView
         android:id="@+id/listTime"
         android:layout_width="55dp"
-        android:layout_height="wrap_content"
+        android:layout_height="fill_parent"
+        android:gravity="center_vertical"
         android:text="@string/clock" />
 
     <TextView
         android:id="@+id/listCount"
         android:layout_width="35dp"
-        android:layout_height="wrap_content"
+        android:layout_height="fill_parent"
         android:layout_marginStart="10dp"
+        android:gravity="center_vertical"
         android:text="@string/zero" />
 
     <TextView
         android:id="@+id/listComment"
         android:layout_width="150dp"
-        android:layout_height="wrap_content"
+        android:layout_height="fill_parent"
         android:layout_marginStart="20dp"
+        android:gravity="center_vertical"
         android:text="@string/comment" />
 
     <Button
         android:id="@+id/listButton"
         android:layout_width="60dp"
-        android:layout_height="wrap_content"
+        android:layout_height="fill_parent"
         android:text="@string/delete" />
 </LinearLayout>

--- a/app/src/main/res/layout/list.xml
+++ b/app/src/main/res/layout/list.xml
@@ -15,7 +15,7 @@
         android:text="@string/clock" />
 
     <TextView
-        android:id="@+id/listNumber"
+        android:id="@+id/listCount"
         android:layout_width="35dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="10dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="app_name">在庫管理</string>
-    <string name="suuryo">数量</string>
+    <string name="action_bar">Freemake</string>
+    <string name="quantity">数量</string>
     <string name="plus">+</string>
     <string name="minus">-</string>
     <string name="zero">0</string>


### PR DESCRIPTION
## チケットURL
https://github.com/freemake-morikawa/zaikokanri/pull/16

## 対応内容・対応背景・妥協点
- Issue6-4 背景色は、選択済み、奇数行、偶数行で色分けする

## やったこと
- 偶数行は背景色を変更する
- 選択済みの行はチェックしたときに背景色を変更する
- 選択解除した行は背景色を変更する
- 変数名、関数名、クラス名、レイアウトファイルのidの見直し

## やっていないこと

## UI:before/after
- after
https://user-images.githubusercontent.com/115610835/198534968-c91d16ca-6690-4755-bc88-47e34c0a09c5.mp4

## テスト
- データの追加をひたすらする > 奇数行、偶数行の色分けはできているか
- チェック、チェック解除を行う > チェック済みの背景色になっているか、チェック解除後は奇数行、偶数行の色分けに戻っているか
- チェック→データ追加 > 挙動に変なところはないか