### PR TITLE
Issue24 一覧/入力画面に戻る

### DIFF
--- a/app/src/main/java/com/example/zaikokanri/InventoryItemDetailActivity.java
+++ b/app/src/main/java/com/example/zaikokanri/InventoryItemDetailActivity.java
@@ -5,6 +5,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.os.Bundle;
 import android.util.Log;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.ImageButton;
 import android.widget.ImageView;
@@ -77,5 +78,16 @@ public class InventoryItemDetailActivity extends AppCompatActivity {
                 Log.d("Exception", e.toString());
             }
         }
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+
+        switch(item.getItemId()) {
+            case android.R.id.home:
+                finish();
+                return true;
+        }
+        return super.onOptionsItemSelected(item);
     }
 }

--- a/app/src/main/java/com/example/zaikokanri/InventoryItemDetailActivity.java
+++ b/app/src/main/java/com/example/zaikokanri/InventoryItemDetailActivity.java
@@ -10,6 +10,7 @@ import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 
 import java.io.InputStream;
@@ -24,6 +25,9 @@ public class InventoryItemDetailActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_inventory_item_detail);
+
+        ActionBar actionBar = getSupportActionBar();
+        actionBar.setDisplayHomeAsUpEnabled(true);
 
         initView();
     }
@@ -40,9 +44,10 @@ public class InventoryItemDetailActivity extends AppCompatActivity {
         final TextView inventoryCountTextView = findViewById(R.id.detail_activity_inventory_count_text_view);
         inventoryCountTextView.setText(String.valueOf(inventoryCount));
 
+        // コメントはActionBarに表示
         final String comment = intent.getStringExtra(Constants.INTENT_KEY_COMMENT);
-        final TextView commentTextView = findViewById(R.id.detail_activity_comment_text_view);
-        commentTextView.setText(comment);
+        final ActionBar actionBar = getSupportActionBar();
+        actionBar.setTitle(comment);
 
         // 画像選択
         imageView = findViewById(R.id.detail_activity_selected_image_view);

--- a/app/src/main/java/com/example/zaikokanri/InventoryItemDetailActivity.java
+++ b/app/src/main/java/com/example/zaikokanri/InventoryItemDetailActivity.java
@@ -45,7 +45,6 @@ public class InventoryItemDetailActivity extends AppCompatActivity {
         final TextView inventoryCountTextView = findViewById(R.id.detail_activity_inventory_count_text_view);
         inventoryCountTextView.setText(String.valueOf(inventoryCount));
 
-        // コメントはActionBarに表示
         final String comment = intent.getStringExtra(Constants.INTENT_KEY_COMMENT);
         final ActionBar actionBar = getSupportActionBar();
         actionBar.setTitle(comment);

--- a/app/src/main/res/layout/activity_inventory_item_detail.xml
+++ b/app/src/main/res/layout/activity_inventory_item_detail.xml
@@ -48,7 +48,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textSize="@dimen/detail_activity_text_size"
-        app:layout_constraintBottom_toTopOf="@+id/detail_activity_comment_text_view"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
 
     <TextView
@@ -57,7 +57,7 @@
         android:layout_height="wrap_content"
         android:text="@string/quantity_text_view_text"
         android:textSize="@dimen/detail_activity_text_size"
-        app:layout_constraintBottom_toTopOf="@+id/detail_activity_comment_text_view"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/detail_activity_inventory_count_text_view" />
 
     <TextView
@@ -65,16 +65,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textSize="@dimen/detail_activity_text_size"
-        app:layout_constraintBottom_toTopOf="@+id/detail_activity_comment_text_view"
-        app:layout_constraintEnd_toEndOf="parent" />
-
-    <TextView
-        android:id="@+id/detail_activity_comment_text_view"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:textSize="@dimen/detail_activity_text_size"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
-
+        app:layout_constraintEnd_toEndOf="parent" />
+    
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## チケットURL
https://github.com/freemake-morikawa/zaikokanri/pull/29

## 対応内容・対応背景・妥協点
- 一覧/入力画面に戻る
- コメント表示箇所をActionBarに変更

## やったこと
- コメント表示箇所を画面下部TextViewからActionBarに変更
	製作課題のGoogleスプレッドシートからその仕様になっていると判断したため
- 詳細画面のActionBarに戻るボタンの実装
- 戻るボタンを押した際にActivityをfinish()して一覧/入力画面に遷移

## UI:before/after
- before
<img width="302" alt="無題" src="https://user-images.githubusercontent.com/115610835/206952720-00bf0587-37f7-4a18-a16f-4ef588046213.png">

- after
https://user-images.githubusercontent.com/115610835/206952694-370e869a-ee3c-4991-80f6-93cc5732baa8.mp4

## テスト
- 詳細画面に移動 > 戻るボタンで一覧/入力画面に移動するか
- 詳細画面に移動 > 画像選択 > 戻るボタンで一覧/入力画面に移動するか
- 詳細画面に移動 > 端末バックキーで一覧/入力画面に移動するか
- 詳細画面に移動 > 画像選択 > 端末バックキーで一覧/入力画面に移動するか