### PR TITLE
Issue24-2,25,26 Applicationクラスにデータを保存し、Activity間で共有する

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="com.example.zaikokanri">
 
     <application
+        android:name=".MyApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/java/com/example/zaikokanri/Constants.java
+++ b/app/src/main/java/com/example/zaikokanri/Constants.java
@@ -6,6 +6,7 @@ public class Constants {
     public static final String INTENT_KEY_TIME_STRING = "time_string";
     public static final String INTENT_KEY_INVENTORY_COUNT = "inventory_count";
     public static final String INTENT_KEY_COMMENT = "comment";
+    public static final String INTENT_KEY_POSITION = "position";
     public static final String EXCEPTION = "Exception";
 
     private Constants() {

--- a/app/src/main/java/com/example/zaikokanri/InventoryInfoListViewAdapter.java
+++ b/app/src/main/java/com/example/zaikokanri/InventoryInfoListViewAdapter.java
@@ -101,7 +101,7 @@ public final class InventoryInfoListViewAdapter extends ArrayAdapter
 
         final int position = (int) v.getTag();
         remove(getItem(position));
-        MyApplication.removeImage(position);
+        MyApplication.getInstance().removeImage(position);
         notifyDataSetChanged();
     }
 

--- a/app/src/main/java/com/example/zaikokanri/InventoryInfoListViewAdapter.java
+++ b/app/src/main/java/com/example/zaikokanri/InventoryInfoListViewAdapter.java
@@ -1,7 +1,6 @@
 package com.example.zaikokanri;
 
 import android.content.Context;
-import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -13,9 +12,6 @@ import android.widget.CompoundButton;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
-
-import java.util.HashMap;
-import java.util.Map;
 
 public final class InventoryInfoListViewAdapter extends ArrayAdapter
         implements View.OnClickListener, CompoundButton.OnCheckedChangeListener {
@@ -105,7 +101,7 @@ public final class InventoryInfoListViewAdapter extends ArrayAdapter
 
         final int position = (int) v.getTag();
         remove(getItem(position));
-        MyApplication.alignPositionImageMap(position);
+        MyApplication.removeImage(position);
         notifyDataSetChanged();
     }
 

--- a/app/src/main/java/com/example/zaikokanri/InventoryInfoListViewAdapter.java
+++ b/app/src/main/java/com/example/zaikokanri/InventoryInfoListViewAdapter.java
@@ -1,6 +1,7 @@
 package com.example.zaikokanri;
 
 import android.content.Context;
+import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -13,6 +14,9 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public final class InventoryInfoListViewAdapter extends ArrayAdapter
         implements View.OnClickListener, CompoundButton.OnCheckedChangeListener {
 
@@ -23,13 +27,16 @@ public final class InventoryInfoListViewAdapter extends ArrayAdapter
     private LayoutInflater inflater;
     private int itemLayout;
     private View.OnClickListener detailButtonOnClickListener;
+    private MyApplication app;
 
     InventoryInfoListViewAdapter(final Context context, final int itemLayout,
-                                 final View.OnClickListener onClickListener) {
+                                 final View.OnClickListener onClickListener,
+                                 final MyApplication app) {
         super(context, itemLayout);
         this.inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
         this.itemLayout = itemLayout;
         this.detailButtonOnClickListener = onClickListener;
+        this.app = app;
     }
 
     @Override
@@ -101,6 +108,7 @@ public final class InventoryInfoListViewAdapter extends ArrayAdapter
 
         final int position = (int) v.getTag();
         remove(getItem(position));
+        updateApplicationMap(position);
         notifyDataSetChanged();
     }
 
@@ -111,5 +119,18 @@ public final class InventoryInfoListViewAdapter extends ArrayAdapter
             color = ITEM_BACKGROUND_COLOR_CHECKED;
         }
         view.setBackgroundColor(color);
+    }
+
+    // 削除ボタン押下時のApplication.Mapの処理
+    private void updateApplicationMap(final int position) {
+        app.imageMap.remove(position);
+        final Map<Integer, Bitmap> buf = new HashMap<>();
+
+        for (Map.Entry<Integer, Bitmap> entry : app.imageMap.entrySet()) {
+            if (position < entry.getKey()) {
+                buf.put(entry.getKey() - 1, entry.getValue());
+            }
+            app.imageMap = new HashMap<>(buf);
+        }
     }
 }

--- a/app/src/main/java/com/example/zaikokanri/InventoryInfoListViewAdapter.java
+++ b/app/src/main/java/com/example/zaikokanri/InventoryInfoListViewAdapter.java
@@ -27,16 +27,13 @@ public final class InventoryInfoListViewAdapter extends ArrayAdapter
     private LayoutInflater inflater;
     private int itemLayout;
     private View.OnClickListener detailButtonOnClickListener;
-    private MyApplication app;
 
     InventoryInfoListViewAdapter(final Context context, final int itemLayout,
-                                 final View.OnClickListener onClickListener,
-                                 final MyApplication app) {
+                                 final View.OnClickListener onClickListener) {
         super(context, itemLayout);
         this.inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
         this.itemLayout = itemLayout;
         this.detailButtonOnClickListener = onClickListener;
-        this.app = app;
     }
 
     @Override
@@ -123,14 +120,14 @@ public final class InventoryInfoListViewAdapter extends ArrayAdapter
 
     // 削除ボタン押下時のApplication.Mapの処理
     private void updateApplicationMap(final int position) {
-        app.imageMap.remove(position);
+        MyApplication.getImageMap().remove(position);
         final Map<Integer, Bitmap> buf = new HashMap<>();
 
-        for (Map.Entry<Integer, Bitmap> entry : app.imageMap.entrySet()) {
+        for (Map.Entry<Integer, Bitmap> entry : MyApplication.getImageMap().entrySet()) {
             if (position < entry.getKey()) {
                 buf.put(entry.getKey() - 1, entry.getValue());
             }
-            app.imageMap = new HashMap<>(buf);
+            MyApplication.setImageMap(new HashMap<>(buf));
         }
     }
 }

--- a/app/src/main/java/com/example/zaikokanri/InventoryInfoListViewAdapter.java
+++ b/app/src/main/java/com/example/zaikokanri/InventoryInfoListViewAdapter.java
@@ -105,7 +105,7 @@ public final class InventoryInfoListViewAdapter extends ArrayAdapter
 
         final int position = (int) v.getTag();
         remove(getItem(position));
-        updateApplicationMap(position);
+        MyApplication.alignPositionImageMap(position);
         notifyDataSetChanged();
     }
 
@@ -116,20 +116,5 @@ public final class InventoryInfoListViewAdapter extends ArrayAdapter
             color = ITEM_BACKGROUND_COLOR_CHECKED;
         }
         view.setBackgroundColor(color);
-    }
-
-    // 削除ボタン押下時のApplication.Mapの処理
-    private void updateApplicationMap(final int position) {
-        MyApplication.getImageMap().remove(position);
-        final Map<Integer, Bitmap> buf = new HashMap<>();
-
-        for (Map.Entry<Integer, Bitmap> entry : MyApplication.getImageMap().entrySet()) {
-            if (position < entry.getKey()) {
-                buf.put(entry.getKey() - 1, entry.getValue());
-            }
-        }
-        if (buf.size() > 0) {
-            MyApplication.setImageMap(new HashMap<>(buf));
-        }
     }
 }

--- a/app/src/main/java/com/example/zaikokanri/InventoryInfoListViewAdapter.java
+++ b/app/src/main/java/com/example/zaikokanri/InventoryInfoListViewAdapter.java
@@ -127,6 +127,8 @@ public final class InventoryInfoListViewAdapter extends ArrayAdapter
             if (position < entry.getKey()) {
                 buf.put(entry.getKey() - 1, entry.getValue());
             }
+        }
+        if (buf.size() > 0) {
             MyApplication.setImageMap(new HashMap<>(buf));
         }
     }

--- a/app/src/main/java/com/example/zaikokanri/InventoryItemDetailActivity.java
+++ b/app/src/main/java/com/example/zaikokanri/InventoryItemDetailActivity.java
@@ -53,8 +53,8 @@ public class InventoryItemDetailActivity extends AppCompatActivity {
 
         imageView = findViewById(R.id.detail_activity_selected_image_view);
         final int position = intent.getIntExtra(Constants.INTENT_KEY_POSITION, INTENT_INT_EXTRA_DEFAULT_VALUE);
-        if (!MyApplication.getImageMap().isEmpty() && MyApplication.getImageMap().get(position) != null) {
-            final Bitmap bitmap = MyApplication.getImageMap().get(position);
+        if (!MyApplication.isEmpty() && MyApplication.getImage(position) != null) {
+            final Bitmap bitmap = MyApplication.getImage(position);
             imageView.setImageBitmap(bitmap);
         }
 
@@ -82,7 +82,7 @@ public class InventoryItemDetailActivity extends AppCompatActivity {
                 imageView.setImageBitmap(bitmap);
 
                 final int position = getIntent().getIntExtra(Constants.INTENT_KEY_POSITION, INTENT_INT_EXTRA_DEFAULT_VALUE);
-                MyApplication.putImageMap(position, bitmap);
+                MyApplication.addImage(bitmap, position);
             } catch (final FileNotFoundException e) {
                 Log.d(Constants.EXCEPTION, e.toString());
             }

--- a/app/src/main/java/com/example/zaikokanri/InventoryItemDetailActivity.java
+++ b/app/src/main/java/com/example/zaikokanri/InventoryItemDetailActivity.java
@@ -22,6 +22,7 @@ public class InventoryItemDetailActivity extends AppCompatActivity {
     private static final int INTENT_INT_EXTRA_DEFAULT_VALUE = 0;
     private static final int REQUEST_GALLERY = 0;
     private ImageView imageView;
+    private MyApplication app;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -31,6 +32,7 @@ public class InventoryItemDetailActivity extends AppCompatActivity {
         ActionBar actionBar = getSupportActionBar();
         actionBar.setDisplayHomeAsUpEnabled(true);
 
+        app = (MyApplication) this.getApplication();
         initView();
     }
 
@@ -50,8 +52,13 @@ public class InventoryItemDetailActivity extends AppCompatActivity {
         final ActionBar actionBar = getSupportActionBar();
         actionBar.setTitle(comment);
 
-        // 画像選択
         imageView = findViewById(R.id.detail_activity_selected_image_view);
+        final int position = intent.getIntExtra(Constants.INTENT_KEY_POSITION, INTENT_INT_EXTRA_DEFAULT_VALUE);
+        if (!app.imageMap.isEmpty() && app.imageMap.get(position) != null) {
+            final Bitmap bitmap = app.imageMap.get(position);
+            imageView.setImageBitmap(bitmap);
+        }
+
         final ImageButton photoLibraryImageButton = findViewById(
                 R.id.detail_activity_photo_library_image_button
         );
@@ -74,6 +81,9 @@ public class InventoryItemDetailActivity extends AppCompatActivity {
                 final InputStream inputStream = getContentResolver().openInputStream(data.getData());
                 final Bitmap bitmap = BitmapFactory.decodeStream(inputStream);
                 imageView.setImageBitmap(bitmap);
+
+                final int position = getIntent().getIntExtra(Constants.INTENT_KEY_POSITION, INTENT_INT_EXTRA_DEFAULT_VALUE);
+                app.imageMap.put(position, bitmap);
             } catch (final FileNotFoundException e) {
                 Log.d(Constants.EXCEPTION, e.toString());
             }

--- a/app/src/main/java/com/example/zaikokanri/InventoryItemDetailActivity.java
+++ b/app/src/main/java/com/example/zaikokanri/InventoryItemDetailActivity.java
@@ -53,8 +53,8 @@ public class InventoryItemDetailActivity extends AppCompatActivity {
 
         imageView = findViewById(R.id.detail_activity_selected_image_view);
         final int position = intent.getIntExtra(Constants.INTENT_KEY_POSITION, INTENT_INT_EXTRA_DEFAULT_VALUE);
-        if (!MyApplication.isEmpty() && MyApplication.getImage(position) != null) {
-            final Bitmap bitmap = MyApplication.getImage(position);
+        if (MyApplication.getInstance().imagesCount() != 0 && MyApplication.getInstance().getImage(position) != null) {
+            final Bitmap bitmap = MyApplication.getInstance().getImage(position);
             imageView.setImageBitmap(bitmap);
         }
 
@@ -82,7 +82,7 @@ public class InventoryItemDetailActivity extends AppCompatActivity {
                 imageView.setImageBitmap(bitmap);
 
                 final int position = getIntent().getIntExtra(Constants.INTENT_KEY_POSITION, INTENT_INT_EXTRA_DEFAULT_VALUE);
-                MyApplication.addImage(bitmap, position);
+                MyApplication.getInstance().addImage(bitmap, position);
             } catch (final FileNotFoundException e) {
                 Log.d(Constants.EXCEPTION, e.toString());
             }

--- a/app/src/main/java/com/example/zaikokanri/InventoryItemDetailActivity.java
+++ b/app/src/main/java/com/example/zaikokanri/InventoryItemDetailActivity.java
@@ -82,7 +82,7 @@ public class InventoryItemDetailActivity extends AppCompatActivity {
                 imageView.setImageBitmap(bitmap);
 
                 final int position = getIntent().getIntExtra(Constants.INTENT_KEY_POSITION, INTENT_INT_EXTRA_DEFAULT_VALUE);
-                MyApplication.getImageMap().put(position, bitmap);
+                MyApplication.putImageMap(position, bitmap);
             } catch (final FileNotFoundException e) {
                 Log.d(Constants.EXCEPTION, e.toString());
             }

--- a/app/src/main/java/com/example/zaikokanri/InventoryItemDetailActivity.java
+++ b/app/src/main/java/com/example/zaikokanri/InventoryItemDetailActivity.java
@@ -53,7 +53,7 @@ public class InventoryItemDetailActivity extends AppCompatActivity {
 
         imageView = findViewById(R.id.detail_activity_selected_image_view);
         final int position = intent.getIntExtra(Constants.INTENT_KEY_POSITION, INTENT_INT_EXTRA_DEFAULT_VALUE);
-        if (MyApplication.getInstance().imagesCount() != 0 && MyApplication.getInstance().getImage(position) != null) {
+        if (MyApplication.getInstance().hasImage(position)) {
             final Bitmap bitmap = MyApplication.getInstance().getImage(position);
             imageView.setImageBitmap(bitmap);
         }

--- a/app/src/main/java/com/example/zaikokanri/InventoryItemDetailActivity.java
+++ b/app/src/main/java/com/example/zaikokanri/InventoryItemDetailActivity.java
@@ -82,7 +82,7 @@ public class InventoryItemDetailActivity extends AppCompatActivity {
                 imageView.setImageBitmap(bitmap);
 
                 final int position = getIntent().getIntExtra(Constants.INTENT_KEY_POSITION, INTENT_INT_EXTRA_DEFAULT_VALUE);
-                MyApplication.getInstance().addImage(bitmap, position);
+                MyApplication.getInstance().setImage(position, bitmap);
             } catch (final FileNotFoundException e) {
                 Log.d(Constants.EXCEPTION, e.toString());
             }

--- a/app/src/main/java/com/example/zaikokanri/InventoryItemDetailActivity.java
+++ b/app/src/main/java/com/example/zaikokanri/InventoryItemDetailActivity.java
@@ -21,6 +21,7 @@ public class InventoryItemDetailActivity extends AppCompatActivity {
 
     private static final int INTENT_INT_EXTRA_DEFAULT_VALUE = 0;
     private static final int REQUEST_GALLERY = 0;
+    private static final String INTENT_TYPE_IMAGE = "image/*";
     private ImageView imageView;
 
     @Override
@@ -64,7 +65,7 @@ public class InventoryItemDetailActivity extends AppCompatActivity {
             @Override
             public void onClick(final View view) {
                 final Intent intent = new Intent();
-                intent.setType("image/*");
+                intent.setType(INTENT_TYPE_IMAGE);
                 intent.setAction(Intent.ACTION_GET_CONTENT);
                 startActivityForResult(intent, REQUEST_GALLERY);
             }

--- a/app/src/main/java/com/example/zaikokanri/InventoryItemDetailActivity.java
+++ b/app/src/main/java/com/example/zaikokanri/InventoryItemDetailActivity.java
@@ -22,7 +22,6 @@ public class InventoryItemDetailActivity extends AppCompatActivity {
     private static final int INTENT_INT_EXTRA_DEFAULT_VALUE = 0;
     private static final int REQUEST_GALLERY = 0;
     private ImageView imageView;
-    private MyApplication app;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -32,7 +31,6 @@ public class InventoryItemDetailActivity extends AppCompatActivity {
         ActionBar actionBar = getSupportActionBar();
         actionBar.setDisplayHomeAsUpEnabled(true);
 
-        app = (MyApplication) this.getApplication();
         initView();
     }
 
@@ -54,8 +52,8 @@ public class InventoryItemDetailActivity extends AppCompatActivity {
 
         imageView = findViewById(R.id.detail_activity_selected_image_view);
         final int position = intent.getIntExtra(Constants.INTENT_KEY_POSITION, INTENT_INT_EXTRA_DEFAULT_VALUE);
-        if (!app.imageMap.isEmpty() && app.imageMap.get(position) != null) {
-            final Bitmap bitmap = app.imageMap.get(position);
+        if (!MyApplication.getImageMap().isEmpty() && MyApplication.getImageMap().get(position) != null) {
+            final Bitmap bitmap = MyApplication.getImageMap().get(position);
             imageView.setImageBitmap(bitmap);
         }
 
@@ -83,7 +81,7 @@ public class InventoryItemDetailActivity extends AppCompatActivity {
                 imageView.setImageBitmap(bitmap);
 
                 final int position = getIntent().getIntExtra(Constants.INTENT_KEY_POSITION, INTENT_INT_EXTRA_DEFAULT_VALUE);
-                app.imageMap.put(position, bitmap);
+                MyApplication.getImageMap().put(position, bitmap);
             } catch (final FileNotFoundException e) {
                 Log.d(Constants.EXCEPTION, e.toString());
             }

--- a/app/src/main/java/com/example/zaikokanri/MainActivity.java
+++ b/app/src/main/java/com/example/zaikokanri/MainActivity.java
@@ -31,6 +31,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     private ArrayAdapter<InventoryInfo> adapter;
     private TextView clockTextView;
     private Timer timer;
+    private MyApplication app;
 
     public MainActivity() {
         inventoryCount = 0;
@@ -44,6 +45,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
+        app = (MyApplication) this.getApplication();
         getSupportActionBar().setTitle(R.string.action_bar_text);
 
         initView();
@@ -72,6 +74,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         final InventoryInfo inventoryInfo = adapter.getItem(position);
 
         final Intent intent = new Intent(MainActivity.this, InventoryItemDetailActivity.class);
+        intent.putExtra(Constants.INTENT_KEY_POSITION, position);
         intent.putExtra(Constants.INTENT_KEY_TIME_STRING, inventoryInfo.getTimeString());
         intent.putExtra(Constants.INTENT_KEY_INVENTORY_COUNT, inventoryInfo.getInventoryCount());
         intent.putExtra(Constants.INTENT_KEY_COMMENT, inventoryInfo.getComment());
@@ -127,7 +130,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
 
         // リスト追加
         final ListView listView = findViewById(R.id.inventory_info_list_view);
-        adapter = new InventoryInfoListViewAdapter(this, R.layout.list_item, this);
+        adapter = new InventoryInfoListViewAdapter(this, R.layout.list_item, this, app);
 
         final Button addInventoryInfoButton = findViewById(R.id.add_inventory_info_button);
         addInventoryInfoButton.setOnClickListener(new View.OnClickListener() {
@@ -152,6 +155,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
             @Override
             public void onClick(final View v) {
                 adapter.clear();
+                app.imageMap.clear();
             }
         });
 

--- a/app/src/main/java/com/example/zaikokanri/MainActivity.java
+++ b/app/src/main/java/com/example/zaikokanri/MainActivity.java
@@ -72,7 +72,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         final int position = (int) v.getTag();
         final InventoryInfo inventoryInfo = adapter.getItem(position);
 
-        final Intent intent = new Intent(MainActivity.this, InventoryItemDetailActivity.class);
+        final Intent intent = new Intent(this, InventoryItemDetailActivity.class);
         intent.putExtra(Constants.INTENT_KEY_POSITION, position);
         intent.putExtra(Constants.INTENT_KEY_TIME_STRING, inventoryInfo.getTimeString());
         intent.putExtra(Constants.INTENT_KEY_INVENTORY_COUNT, inventoryInfo.getInventoryCount());

--- a/app/src/main/java/com/example/zaikokanri/MainActivity.java
+++ b/app/src/main/java/com/example/zaikokanri/MainActivity.java
@@ -44,7 +44,6 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        MyApplication.getInstance();
         getSupportActionBar().setTitle(R.string.action_bar_text);
 
         initView();
@@ -154,7 +153,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
             @Override
             public void onClick(final View v) {
                 adapter.clear();
-                MyApplication.getImageMap().clear();
+                MyApplication.clearImageMap();
             }
         });
 

--- a/app/src/main/java/com/example/zaikokanri/MainActivity.java
+++ b/app/src/main/java/com/example/zaikokanri/MainActivity.java
@@ -1,6 +1,7 @@
 package com.example.zaikokanri;
 
 import android.content.Intent;
+import android.graphics.Bitmap;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.ArrayAdapter;
@@ -143,6 +144,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                         inventoryCountTextView.getText().toString(),
                         commentEditText.getText().toString());
                 adapter.add(inventoryInfo);
+                MyApplication.addImageSpace();
                 listView.setAdapter(adapter);
             }
         });
@@ -153,7 +155,6 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
             @Override
             public void onClick(final View v) {
                 adapter.clear();
-                MyApplication.clearImageMap();
             }
         });
 
@@ -173,7 +174,6 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
 
                 args.putInt(Constants.BUNDLE_KEY_COUNT, totalInventoryCount);
                 dialogFragment.setArguments(args);
-
                 dialogFragment.show(getSupportFragmentManager(), TAG_DIALOG);
             }
         });

--- a/app/src/main/java/com/example/zaikokanri/MainActivity.java
+++ b/app/src/main/java/com/example/zaikokanri/MainActivity.java
@@ -144,7 +144,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                         inventoryCountTextView.getText().toString(),
                         commentEditText.getText().toString());
                 adapter.add(inventoryInfo);
-                MyApplication.getInstance().addImageSpace();
+                MyApplication.getInstance().setImage(adapter.getCount(), null);
                 listView.setAdapter(adapter);
             }
         });

--- a/app/src/main/java/com/example/zaikokanri/MainActivity.java
+++ b/app/src/main/java/com/example/zaikokanri/MainActivity.java
@@ -31,7 +31,6 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     private ArrayAdapter<InventoryInfo> adapter;
     private TextView clockTextView;
     private Timer timer;
-    private MyApplication app;
 
     public MainActivity() {
         inventoryCount = 0;
@@ -45,7 +44,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        app = (MyApplication) this.getApplication();
+        MyApplication.getInstance();
         getSupportActionBar().setTitle(R.string.action_bar_text);
 
         initView();
@@ -130,7 +129,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
 
         // リスト追加
         final ListView listView = findViewById(R.id.inventory_info_list_view);
-        adapter = new InventoryInfoListViewAdapter(this, R.layout.list_item, this, app);
+        adapter = new InventoryInfoListViewAdapter(this, R.layout.list_item, this);
 
         final Button addInventoryInfoButton = findViewById(R.id.add_inventory_info_button);
         addInventoryInfoButton.setOnClickListener(new View.OnClickListener() {
@@ -155,7 +154,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
             @Override
             public void onClick(final View v) {
                 adapter.clear();
-                app.imageMap.clear();
+                MyApplication.getImageMap().clear();
             }
         });
 

--- a/app/src/main/java/com/example/zaikokanri/MainActivity.java
+++ b/app/src/main/java/com/example/zaikokanri/MainActivity.java
@@ -144,7 +144,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                         inventoryCountTextView.getText().toString(),
                         commentEditText.getText().toString());
                 adapter.add(inventoryInfo);
-                MyApplication.addImageSpace();
+                MyApplication.getInstance().addImageSpace();
                 listView.setAdapter(adapter);
             }
         });

--- a/app/src/main/java/com/example/zaikokanri/MyApplication.java
+++ b/app/src/main/java/com/example/zaikokanri/MyApplication.java
@@ -17,15 +17,28 @@ public class MyApplication extends Application {
         instance = this;
     }
 
-    public static MyApplication getInstance() {
-        return instance;
-    }
-
     public static Map<Integer, Bitmap> getImageMap() {
         return imageMap;
     }
 
-    public static void setImageMap(Map<Integer, Bitmap> imageMap) {
-        MyApplication.imageMap = imageMap;
+    public static void alignPositionImageMap(final int position) {
+        imageMap.remove(position);
+        final Map<Integer, Bitmap> buf = new HashMap<>();
+        for (Map.Entry<Integer, Bitmap> entry : imageMap.entrySet()) {
+            if (position < entry.getKey()) {
+                buf.put(entry.getKey() - 1, entry.getValue());
+            }
+            if (buf.size() > 0) {
+                imageMap = buf;
+            }
+        }
+    }
+
+    public static void putImageMap(final int position, final Bitmap bitmap) {
+        imageMap.put(position, bitmap);
+    }
+
+    public static void clearImageMap() {
+        imageMap.clear();
     }
 }

--- a/app/src/main/java/com/example/zaikokanri/MyApplication.java
+++ b/app/src/main/java/com/example/zaikokanri/MyApplication.java
@@ -1,0 +1,12 @@
+package com.example.zaikokanri;
+
+import android.app.Application;
+import android.graphics.Bitmap;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MyApplication extends Application {
+
+    public static Map<Integer, Bitmap> imageMap = new HashMap<>();
+}

--- a/app/src/main/java/com/example/zaikokanri/MyApplication.java
+++ b/app/src/main/java/com/example/zaikokanri/MyApplication.java
@@ -28,9 +28,9 @@ public class MyApplication extends Application {
     public void setImage(final int position, final Bitmap bitmap) {
         if (imageList.size() < position) {
             imageList.add(null);
-        } else {
-            imageList.set(position, bitmap);
+            return;
         }
+        imageList.set(position, bitmap);
     }
 
     public void removeImage(final int position) {

--- a/app/src/main/java/com/example/zaikokanri/MyApplication.java
+++ b/app/src/main/java/com/example/zaikokanri/MyApplication.java
@@ -8,5 +8,24 @@ import java.util.Map;
 
 public class MyApplication extends Application {
 
-    public static Map<Integer, Bitmap> imageMap = new HashMap<>();
+    private static MyApplication instance = null;
+    private static Map<Integer, Bitmap> imageMap = new HashMap<>();
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        instance = this;
+    }
+
+    public static MyApplication getInstance() {
+        return instance;
+    }
+
+    public static Map<Integer, Bitmap> getImageMap() {
+        return imageMap;
+    }
+
+    public static void setImageMap(Map<Integer, Bitmap> imageMap) {
+        MyApplication.imageMap = imageMap;
+    }
 }

--- a/app/src/main/java/com/example/zaikokanri/MyApplication.java
+++ b/app/src/main/java/com/example/zaikokanri/MyApplication.java
@@ -16,11 +16,7 @@ public class MyApplication extends Application {
         super.onCreate();
         instance = this;
     }
-
-    public static Map<Integer, Bitmap> getImageMap() {
-        return imageMap;
-    }
-
+    
     public static void alignPositionImageMap(final int position) {
         imageMap.remove(position);
         final Map<Integer, Bitmap> buf = new HashMap<>();

--- a/app/src/main/java/com/example/zaikokanri/MyApplication.java
+++ b/app/src/main/java/com/example/zaikokanri/MyApplication.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public class MyApplication extends Application {
 
-    private static MyApplication instance = null;
+    private static MyApplication instance = new MyApplication();
     private static List<Bitmap> imageList = new ArrayList<>();
 
     @Override
@@ -17,24 +17,28 @@ public class MyApplication extends Application {
         instance = this;
     }
 
-    public static Bitmap getImage(final int position) {
+    public static MyApplication getInstance() {
+        return instance;
+    }
+
+    public Bitmap getImage(final int position) {
         return imageList.get(position);
     }
 
-    public static void addImage( final Bitmap bitmap, final int position) {
+    public void addImage( final Bitmap bitmap, final int position) {
         imageList.remove(position);
         imageList.add(position, bitmap);
     }
 
-    public static void addImageSpace() {
+    public void addImageSpace() {
         imageList.add(null);
     }
 
-    public static boolean isEmpty() {
-        return imageList.isEmpty();
+    public int imagesCount() {
+        return imageList.size();
     }
 
-    public static void removeImage(final int position) {
+    public void removeImage(final int position) {
         imageList.remove(position);
     }
 

--- a/app/src/main/java/com/example/zaikokanri/MyApplication.java
+++ b/app/src/main/java/com/example/zaikokanri/MyApplication.java
@@ -25,13 +25,12 @@ public class MyApplication extends Application {
         return imageList.get(position);
     }
 
-    public void addImage( final Bitmap bitmap, final int position) {
-        imageList.remove(position);
-        imageList.add(position, bitmap);
-    }
-
-    public void addImageSpace() {
-        imageList.add(null);
+    public void setImage(final int position, final Bitmap bitmap) {
+        if (imageList.size() < position) {
+            imageList.add(null);
+        } else {
+            imageList.set(position, bitmap);
+        }
     }
 
     public int imagesCount() {

--- a/app/src/main/java/com/example/zaikokanri/MyApplication.java
+++ b/app/src/main/java/com/example/zaikokanri/MyApplication.java
@@ -3,38 +3,39 @@ package com.example.zaikokanri;
 import android.app.Application;
 import android.graphics.Bitmap;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 
 public class MyApplication extends Application {
 
     private static MyApplication instance = null;
-    private static Map<Integer, Bitmap> imageMap = new HashMap<>();
+    private static List<Bitmap> imageList = new ArrayList<>();
 
     @Override
     public void onCreate() {
         super.onCreate();
         instance = this;
     }
-    
-    public static void alignPositionImageMap(final int position) {
-        imageMap.remove(position);
-        final Map<Integer, Bitmap> buf = new HashMap<>();
-        for (Map.Entry<Integer, Bitmap> entry : imageMap.entrySet()) {
-            if (position < entry.getKey()) {
-                buf.put(entry.getKey() - 1, entry.getValue());
-            }
-            if (buf.size() > 0) {
-                imageMap = buf;
-            }
-        }
+
+    public static Bitmap getImage(final int position) {
+        return imageList.get(position);
     }
 
-    public static void putImageMap(final int position, final Bitmap bitmap) {
-        imageMap.put(position, bitmap);
+    public static void addImage( final Bitmap bitmap, final int position) {
+        imageList.remove(position);
+        imageList.add(position, bitmap);
     }
 
-    public static void clearImageMap() {
-        imageMap.clear();
+    public static void addImageSpace() {
+        imageList.add(null);
     }
+
+    public static boolean isEmpty() {
+        return imageList.isEmpty();
+    }
+
+    public static void removeImage(final int position) {
+        imageList.remove(position);
+    }
+
 }

--- a/app/src/main/java/com/example/zaikokanri/MyApplication.java
+++ b/app/src/main/java/com/example/zaikokanri/MyApplication.java
@@ -33,12 +33,15 @@ public class MyApplication extends Application {
         }
     }
 
-    public int imagesCount() {
-        return imageList.size();
-    }
-
     public void removeImage(final int position) {
         imageList.remove(position);
+    }
+
+    public boolean hasImage(final int position) {
+        if (imageList.get(position) == null) {
+            return false;
+        }
+        return true;
     }
 
 }


### PR DESCRIPTION
## チケットURL
https://github.com/freemake-morikawa/zaikokanri/pull/31

## 対応内容・対応背景・妥協点
- 選択ずみの画像は一覧/入力画面でリストの行ごとに管理する
- 一覧/入力画面でリストの行ごとに管理されている選択済みの画像を削除する
- 選択済みの画像があれば表示する

## やったこと
- 選択ずみの画像は一覧/入力画面でリストの行ごとに管理する
	- `Application`クラスにstaticなMapを作り、一覧/入力画面上のポジションとBitmapを保持させる

- 一覧/入力画面でリストの行ごとに管理されている選択済みの画像を削除する
	- 一覧/入力画面で削除ボタンを押した際に、`Activity#imageMap`内の押したアイテムのポジション以上のデータを全てポジション-1する
	- クリアボタンを押した際に`Activity#imageMap`を`clear()`する

- 選択済の画像があれば表示する
	- 意図がよくわからなかったのですが、「画像選択済のアイテムを再度詳細画面に移動した際に画像を表示しておく」と解釈
	- `InventoryItemDetailActivity#initView()`に、押されたアイテムと同じポジションのキーを持つデータがあれば画像を最初から表示するように実装

## やっていないこと

## UI:before/after
- before
https://user-images.githubusercontent.com/115610835/208033661-aa19ee31-b51e-4792-99c9-649885b2d5f0.mp4

- after
容量が大きいためMettermost上に添付

## テスト
- 詳細画面で画像を選択 > 戻る > 一覧/入力画面で同じ項目を選択 > 画像が表示されているか
- 詳細画面で画像を選択 > 別の画像をそのまま選択 > 戻る > 一覧/入力画面で同じ項目を選択 > 画像が表示されているか

- 一覧/入力画面で3つ項目を作成 > それぞれ別の画像を詳細画面で選択 > 戻って再度開いた際にに全て表示されているか
- 一覧/入力画面で3つ項目を作成 > それぞれ別の画像を詳細画面で選択 > 2つ目の項目を削除 > 1つ目と3つ目を開いた際に最初に選択した画像が表示されているか

- 一覧/入力画面で5つ項目を作成 > それぞれで画像を選択 > 戻る > クリア > 再度5つ項目を作成 > 全て画像がなくなっているか
