### PR TITLE
Converterの作成

### DIFF
--- a/app/src/main/java/com/example/zaikokanri/db/AppDatabase.java
+++ b/app/src/main/java/com/example/zaikokanri/db/AppDatabase.java
@@ -6,7 +6,6 @@ import androidx.room.TypeConverters;
 
 @Database(entities = {InventoryData.class}, version = 1, exportSchema = false)
 @TypeConverters({Converters.class})
-
 public abstract class AppDatabase extends RoomDatabase {
     public abstract InventoryDataDao inventoryDataDao();
 }

--- a/app/src/main/java/com/example/zaikokanri/db/AppDatabase.java
+++ b/app/src/main/java/com/example/zaikokanri/db/AppDatabase.java
@@ -2,8 +2,11 @@ package com.example.zaikokanri.db;
 
 import androidx.room.Database;
 import androidx.room.RoomDatabase;
+import androidx.room.TypeConverters;
 
 @Database(entities = {InventoryData.class}, version = 1)
+@TypeConverters({Converters.class})
+
 public abstract class AppDatabase extends RoomDatabase {
     public abstract InventoryDataDao inventoryDataDao();
 }

--- a/app/src/main/java/com/example/zaikokanri/db/AppDatabase.java
+++ b/app/src/main/java/com/example/zaikokanri/db/AppDatabase.java
@@ -4,7 +4,7 @@ import androidx.room.Database;
 import androidx.room.RoomDatabase;
 import androidx.room.TypeConverters;
 
-@Database(entities = {InventoryData.class}, version = 1)
+@Database(entities = {InventoryData.class}, version = 1, exportSchema = false)
 @TypeConverters({Converters.class})
 
 public abstract class AppDatabase extends RoomDatabase {

--- a/app/src/main/java/com/example/zaikokanri/db/Converters.java
+++ b/app/src/main/java/com/example/zaikokanri/db/Converters.java
@@ -1,0 +1,36 @@
+package com.example.zaikokanri.db;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.util.Base64;
+
+import androidx.room.TypeConverter;
+
+import java.io.ByteArrayOutputStream;
+import java.sql.Timestamp;
+
+public class Converters {
+    @TypeConverter
+    public static Timestamp longToTimestamp(final Long value) {
+        return value == null ? null : new Timestamp(value);
+    }
+
+    @TypeConverter
+    public static Long timestampToLong(final Timestamp timestamp) {
+        return timestamp == null ? null : timestamp.getTime();
+    }
+
+    @TypeConverter
+    public static Bitmap stringToBitmap(final String string) {
+        final byte[] bytes = Base64.decode(string, Base64.DEFAULT);
+        return BitmapFactory.decodeByteArray(bytes, 0, bytes.length);
+    }
+
+    @TypeConverter
+    public static String bitmapToString(final Bitmap bitmap) {
+        final ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream);
+        final byte[] bytes = stream.toByteArray();
+        return Base64.encodeToString(bytes, Base64.DEFAULT);
+    }
+}

--- a/app/src/main/java/com/example/zaikokanri/db/Converters.java
+++ b/app/src/main/java/com/example/zaikokanri/db/Converters.java
@@ -2,7 +2,6 @@ package com.example.zaikokanri.db;
 
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
-import android.util.Base64;
 
 import androidx.room.TypeConverter;
 
@@ -21,16 +20,14 @@ public class Converters {
     }
 
     @TypeConverter
-    public static Bitmap stringToBitmap(final String string) {
-        final byte[] bytes = Base64.decode(string, Base64.DEFAULT);
-        return BitmapFactory.decodeByteArray(bytes, 0, bytes.length);
+    public static byte[] bitmapToByteArray(final Bitmap bitmap) {
+        final ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream);
+        return stream.toByteArray();
     }
 
     @TypeConverter
-    public static String bitmapToString(final Bitmap bitmap) {
-        final ByteArrayOutputStream stream = new ByteArrayOutputStream();
-        bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream);
-        final byte[] bytes = stream.toByteArray();
-        return Base64.encodeToString(bytes, Base64.DEFAULT);
+    public static Bitmap byteArrayToBitmap(final byte[] bytes) {
+        return BitmapFactory.decodeByteArray(bytes, 0, bytes.length);
     }
 }

--- a/app/src/main/java/com/example/zaikokanri/db/Converters.java
+++ b/app/src/main/java/com/example/zaikokanri/db/Converters.java
@@ -3,9 +3,11 @@ package com.example.zaikokanri.db;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 
+import androidx.annotation.NonNull;
 import androidx.room.TypeConverter;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
 import java.sql.Timestamp;
 
 public class Converters {
@@ -21,11 +23,14 @@ public class Converters {
 
     @TypeConverter
     public static byte[] bitmapToByteArray(final Bitmap bitmap) {
-        final ByteArrayOutputStream stream = new ByteArrayOutputStream();
-        bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream);
-        return stream.toByteArray();
+        if (bitmap == null) {
+            return null;
+        }
+        ByteBuffer byteBuffer = ByteBuffer.allocate(bitmap.getByteCount());
+        bitmap.copyPixelsToBuffer(byteBuffer);
+        return byteBuffer.array();
     }
-
+    
     @TypeConverter
     public static Bitmap byteArrayToBitmap(final byte[] bytes) {
         return BitmapFactory.decodeByteArray(bytes, 0, bytes.length);

--- a/app/src/main/java/com/example/zaikokanri/db/InventoryData.java
+++ b/app/src/main/java/com/example/zaikokanri/db/InventoryData.java
@@ -21,8 +21,8 @@ public class InventoryData {
     @ColumnInfo(defaultValue = "NULL")
     public String comment;
 
-    @ColumnInfo(defaultValue = "NULL")
-    public String image;
+    @ColumnInfo(defaultValue = "NULL", typeAffinity = ColumnInfo.BLOB)
+    public byte[] image;
 
     @ColumnInfo(name = "is_delete", defaultValue = "0")
     @NonNull

--- a/app/src/main/java/com/example/zaikokanri/db/InventoryData.java
+++ b/app/src/main/java/com/example/zaikokanri/db/InventoryData.java
@@ -5,7 +5,6 @@ import androidx.room.ColumnInfo;
 import androidx.room.Entity;
 import androidx.room.PrimaryKey;
 
-import java.sql.Blob;
 import java.sql.Timestamp;
 
 @Entity(tableName = "inventory_data")
@@ -23,7 +22,7 @@ public class InventoryData {
     public String comment;
 
     @ColumnInfo(defaultValue = "NULL")
-    public Blob image;
+    public String image;
 
     @ColumnInfo(name = "is_delete", defaultValue = "0")
     @NonNull


### PR DESCRIPTION
## チケットURL
https://github.com/freemake-morikawa/zaikokanri/pull/38

## 対応内容・対応背景・妥協点
- DBにTimestamp型とBitmap型を入れることができないため、それぞれのConverterを作成

## やったこと
- `Converters`クラスの作成
- Timestamp⇔longとString⇔Bitmapの関数を作成
- `InventoryData`クラスの`Blob image`を`String image`に変更
- `eportSchema`をfalseに変更