### PR TITLE
DB追加処理の作成・InventoryDataをprivate finalにしてgetterを追加

### DIFF
--- a/app/src/main/java/com/example/zaikokanri/MainActivity.java
+++ b/app/src/main/java/com/example/zaikokanri/MainActivity.java
@@ -2,7 +2,6 @@ package com.example.zaikokanri;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
@@ -17,7 +16,6 @@ import com.example.zaikokanri.db.InventoryData;
 
 import java.sql.Timestamp;
 import java.text.DecimalFormat;
-import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Timer;

--- a/app/src/main/java/com/example/zaikokanri/MainActivity.java
+++ b/app/src/main/java/com/example/zaikokanri/MainActivity.java
@@ -2,7 +2,6 @@ package com.example.zaikokanri;
 
 import android.app.ProgressDialog;
 import android.content.Intent;
-import android.os.AsyncTask;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.ArrayAdapter;
@@ -157,16 +156,25 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                         commentEditText.getText().toString(),
                         null, true, timestamp, timestamp);
 
-                final AddInventoryDataTask addInventoryDataTask =
-                        new AddInventoryDataTask();
-                startProgressDialog();
-                addInventoryDataTask.setCallBackTask(new AddInventoryDataTask.CallBackTask() {
+                final OperateInventoryDataTask operateInventoryDataTask =
+                        new OperateInventoryDataTask();
+                startProgressDialog(
+                        getText(R.string.progress_dialog_title_add).toString(),
+                        getText(R.string.progress_dialog_message_add).toString()
+                );
+                operateInventoryDataTask.setCallBackTask(new OperateInventoryDataTask.CallBackTask() {
                     @Override
-                    public void CallBack() {
+                    public void callBack() {
                         endProgressDialog();
                     }
                 });
-                addInventoryDataTask.execute(inventoryData);
+                operateInventoryDataTask.setTask(new OperateInventoryDataTask.ExecuteTask() {
+                    @Override
+                    public void task() {
+                        MyApplication.getInstance().getDao().add(inventoryData);
+                    }
+                });
+                operateInventoryDataTask.execute(inventoryData);
             }
         });
 
@@ -229,42 +237,15 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         return false;
     }
 
-    private void startProgressDialog() {
+    private void startProgressDialog(final String title, final String message) {
         progressDialog = new ProgressDialog(this);
-        progressDialog.setTitle(R.string.progress_dialog_title);
-        progressDialog.setMessage(getText(R.string.progress_dialog_message));
+        progressDialog.setTitle(title);
+        progressDialog.setMessage(message);
         progressDialog.setProgressStyle(ProgressDialog.STYLE_SPINNER);
         progressDialog.show();
     }
 
     private void endProgressDialog() {
         progressDialog.dismiss();
-    }
-
-    private static class AddInventoryDataTask extends AsyncTask<InventoryData, Void, Void> {
-
-        private CallBackTask callBackTask;
-
-        @Override
-        protected Void doInBackground(final InventoryData... inventoryData) {
-            for (InventoryData data : inventoryData) {
-                MyApplication.getInstance().getDao().add(data);
-            }
-            return null;
-        }
-
-        @Override
-        protected void onPostExecute(final Void result) {
-            callBackTask.CallBack();
-        }
-
-        public void setCallBackTask(final CallBackTask callBackTask) {
-            this.callBackTask = callBackTask;
-        }
-
-        public abstract static class CallBackTask {
-            public void CallBack() {
-            }
-        }
     }
 }

--- a/app/src/main/java/com/example/zaikokanri/MainActivity.java
+++ b/app/src/main/java/com/example/zaikokanri/MainActivity.java
@@ -2,6 +2,7 @@ package com.example.zaikokanri;
 
 import android.app.ProgressDialog;
 import android.content.Intent;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.ArrayAdapter;
@@ -155,9 +156,17 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                         0, Integer.parseInt(inventoryCountTextView.getText().toString()),
                         commentEditText.getText().toString(),
                         null, true, timestamp, timestamp);
+
+                final AddInventoryDataTask addInventoryDataTask =
+                        new AddInventoryDataTask();
                 startProgressDialog();
-                new Thread(() -> MyApplication.getInstance().getDao().add(inventoryData)).start();
-                endProgressDialog();
+                addInventoryDataTask.setCallBackTask(new AddInventoryDataTask.CallBackTask() {
+                    @Override
+                    public void CallBack() {
+                        endProgressDialog();
+                    }
+                });
+                addInventoryDataTask.execute(inventoryData);
             }
         });
 
@@ -230,5 +239,32 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
 
     private final void endProgressDialog() {
         progressDialog.dismiss();
+    }
+
+    private static class AddInventoryDataTask extends AsyncTask<InventoryData, Void, Void> {
+
+        private CallBackTask callBackTask;
+
+        @Override
+        protected Void doInBackground(final InventoryData... inventoryData) {
+            for (InventoryData data : inventoryData) {
+                MyApplication.getInstance().getDao().add(data);
+            }
+            return null;
+        }
+
+        @Override
+        protected void onPostExecute(final Void result) {
+            callBackTask.CallBack();
+        }
+
+        public void setCallBackTask(final CallBackTask callBackTask) {
+            this.callBackTask = callBackTask;
+        }
+
+        public abstract static class CallBackTask {
+            public void CallBack() {
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/zaikokanri/MainActivity.java
+++ b/app/src/main/java/com/example/zaikokanri/MainActivity.java
@@ -229,7 +229,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         return false;
     }
 
-    private final void startProgressDialog() {
+    private void startProgressDialog() {
         progressDialog = new ProgressDialog(this);
         progressDialog.setTitle(R.string.progress_dialog_title);
         progressDialog.setMessage(getText(R.string.progress_dialog_message));
@@ -237,7 +237,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         progressDialog.show();
     }
 
-    private final void endProgressDialog() {
+    private void endProgressDialog() {
         progressDialog.dismiss();
     }
 

--- a/app/src/main/java/com/example/zaikokanri/MainActivity.java
+++ b/app/src/main/java/com/example/zaikokanri/MainActivity.java
@@ -29,7 +29,6 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     private static final int TIMER_PERIOD = 100;
     private static final String DEFAULT_NUMBER_FORMAT = "#,###";
     private static final String TAG_DIALOG = "dialog";
-    private static final String TAG_EXCEPTION = "Exception";
 
     private int inventoryCount;
     private ArrayAdapter<InventoryInfo> adapter;

--- a/app/src/main/java/com/example/zaikokanri/MainActivity.java
+++ b/app/src/main/java/com/example/zaikokanri/MainActivity.java
@@ -218,14 +218,4 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         }
         return false;
     }
-
-    private Date stringToDate(final String string) {
-        try {
-            final SimpleDateFormat format = new SimpleDateFormat("hh:mm:ss");
-            return format.parse(string);
-        } catch (final ParseException e) {
-            Log.d(TAG_EXCEPTION, e.toString());
-        }
-        return null;
-    }
 }

--- a/app/src/main/java/com/example/zaikokanri/MainActivity.java
+++ b/app/src/main/java/com/example/zaikokanri/MainActivity.java
@@ -2,6 +2,7 @@ package com.example.zaikokanri;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
@@ -12,7 +13,11 @@ import android.widget.TextView;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.DialogFragment;
 
+import com.example.zaikokanri.db.InventoryData;
+
+import java.sql.Timestamp;
 import java.text.DecimalFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Timer;
@@ -26,6 +31,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     private static final int TIMER_PERIOD = 100;
     private static final String DEFAULT_NUMBER_FORMAT = "#,###";
     private static final String TAG_DIALOG = "dialog";
+    private static final String TAG_EXCEPTION = "Exception";
 
     private int inventoryCount;
     private ArrayAdapter<InventoryInfo> adapter;
@@ -137,7 +143,6 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                 final TextView clockTextView = findViewById(R.id.clock_text_view);
                 final TextView inventoryCountTextView = findViewById(R.id.inventory_count_text_view);
                 final EditText commentEditText = findViewById(R.id.comment_edit_text);
-
                 final InventoryInfo inventoryInfo = new InventoryInfo(
                         clockTextView.getText().toString(),
                         inventoryCountTextView.getText().toString(),
@@ -145,6 +150,13 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                 adapter.add(inventoryInfo);
                 MyApplication.getInstance().setImage(adapter.getCount(), null);
                 listView.setAdapter(adapter);
+
+                final Timestamp timestamp = new Timestamp(new Date().getTime());
+                final InventoryData inventoryData = new InventoryData(
+                        0, Integer.parseInt(inventoryCountTextView.getText().toString()),
+                        commentEditText.getText().toString(),
+                        null, true, timestamp, timestamp);
+                new Thread(() -> MyApplication.getDao().add(inventoryData)).start();
             }
         });
 
@@ -205,5 +217,15 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
             }
         }
         return false;
+    }
+
+    private Date stringToDate(final String string) {
+        try {
+            final SimpleDateFormat format = new SimpleDateFormat("hh:mm:ss");
+            return format.parse(string);
+        } catch (final ParseException e) {
+            Log.d(TAG_EXCEPTION, e.toString());
+        }
+        return null;
     }
 }

--- a/app/src/main/java/com/example/zaikokanri/MainActivity.java
+++ b/app/src/main/java/com/example/zaikokanri/MainActivity.java
@@ -51,11 +51,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         setContentView(R.layout.activity_main);
 
         getSupportActionBar().setTitle(R.string.action_bar_text);
-
         initView();
-        startProgressDialog();
-        MyApplication.getInstance().initializeDatabase();
-        progressDialog.dismiss();
     }
 
     @Override
@@ -161,7 +157,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                         null, true, timestamp, timestamp);
                 startProgressDialog();
                 new Thread(() -> MyApplication.getInstance().getDao().add(inventoryData)).start();
-                progressDialog.dismiss();
+                endProgressDialog();
             }
         });
 
@@ -224,11 +220,15 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         return false;
     }
 
-    private void startProgressDialog() {
+    private final void startProgressDialog() {
         progressDialog = new ProgressDialog(this);
         progressDialog.setTitle(R.string.progress_dialog_title);
         progressDialog.setMessage(getText(R.string.progress_dialog_message));
         progressDialog.setProgressStyle(ProgressDialog.STYLE_SPINNER);
         progressDialog.show();
+    }
+
+    private final void endProgressDialog() {
+        progressDialog.dismiss();
     }
 }

--- a/app/src/main/java/com/example/zaikokanri/MainActivity.java
+++ b/app/src/main/java/com/example/zaikokanri/MainActivity.java
@@ -1,5 +1,6 @@
 package com.example.zaikokanri;
 
+import android.app.ProgressDialog;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
@@ -34,12 +35,14 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     private ArrayAdapter<InventoryInfo> adapter;
     private TextView clockTextView;
     private Timer timer;
+    private ProgressDialog progressDialog;
 
     public MainActivity() {
         inventoryCount = 0;
         adapter = null;
         clockTextView = null;
         timer = null;
+        progressDialog = null;
     }
 
     @Override
@@ -50,6 +53,9 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         getSupportActionBar().setTitle(R.string.action_bar_text);
 
         initView();
+        startProgressDialog();
+        MyApplication.getInstance().initializeDatabase();
+        progressDialog.dismiss();
     }
 
     @Override
@@ -153,7 +159,9 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                         0, Integer.parseInt(inventoryCountTextView.getText().toString()),
                         commentEditText.getText().toString(),
                         null, true, timestamp, timestamp);
-                new Thread(() -> MyApplication.getDao().add(inventoryData)).start();
+                startProgressDialog();
+                new Thread(() -> MyApplication.getInstance().getDao().add(inventoryData)).start();
+                progressDialog.dismiss();
             }
         });
 
@@ -214,5 +222,13 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
             }
         }
         return false;
+    }
+
+    private void startProgressDialog() {
+        progressDialog = new ProgressDialog(this);
+        progressDialog.setTitle(R.string.progress_dialog_title);
+        progressDialog.setMessage(getText(R.string.progress_dialog_message));
+        progressDialog.setProgressStyle(ProgressDialog.STYLE_SPINNER);
+        progressDialog.show();
     }
 }

--- a/app/src/main/java/com/example/zaikokanri/MyApplication.java
+++ b/app/src/main/java/com/example/zaikokanri/MyApplication.java
@@ -2,7 +2,6 @@ package com.example.zaikokanri;
 
 import android.app.Application;
 import android.graphics.Bitmap;
-import android.util.Log;
 
 import androidx.room.Room;
 
@@ -26,13 +25,6 @@ public class MyApplication extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
-        new Thread(() -> {
-            db = Room.databaseBuilder(getApplicationContext(),
-                    AppDatabase.class, DATABASE_NAME).build();
-            dao = db.inventoryDataDao();
-            inventoryDataList = dao.getAll();
-            Log.d("Test", inventoryDataList.toString());
-        }).start();
         instance = this;
     }
 
@@ -63,11 +55,27 @@ public class MyApplication extends Application {
         return imageList.get(position) != null;
     }
 
-    public static List<InventoryData> getInventoryDataList() {
+    public List<InventoryData> getInventoryDataList() {
         return inventoryDataList;
     }
 
-    public static InventoryDataDao getDao() {
+    public InventoryDataDao getDao() {
         return dao;
+    }
+
+    public void initializeDatabase() {
+        new GetDatabaseThread().start();
+    }
+
+    // データベースのインスタンスや内容を取得するThread
+    private class GetDatabaseThread extends Thread {
+        @Override
+        public void run() {
+            super.run();
+            db = Room.databaseBuilder(getApplicationContext(),
+                    AppDatabase.class, DATABASE_NAME).build();
+            dao = db.inventoryDataDao();
+            inventoryDataList = dao.getAll();
+        }
     }
 }

--- a/app/src/main/java/com/example/zaikokanri/MyApplication.java
+++ b/app/src/main/java/com/example/zaikokanri/MyApplication.java
@@ -2,6 +2,7 @@ package com.example.zaikokanri;
 
 import android.app.Application;
 import android.graphics.Bitmap;
+import android.util.Log;
 
 import androidx.room.Room;
 
@@ -15,6 +16,7 @@ import java.util.List;
 public class MyApplication extends Application {
 
     private static final String DATABASE_NAME = "inventory_data";
+    private static final String TAG_EXCEPTION = "Exception";
 
     private static MyApplication instance = new MyApplication();
     private static final List<Bitmap> imageList = new ArrayList<>();
@@ -26,6 +28,7 @@ public class MyApplication extends Application {
     public void onCreate() {
         super.onCreate();
         instance = this;
+        initializeDatabase();
     }
 
     public static MyApplication getInstance() {
@@ -64,7 +67,13 @@ public class MyApplication extends Application {
     }
 
     public void initializeDatabase() {
-        new GetDatabaseThread().start();
+        final GetDatabaseThread thread = new GetDatabaseThread();
+        thread.start();
+        try {
+            thread.join();
+        } catch (InterruptedException e) {
+            Log.d(TAG_EXCEPTION, e.toString());
+        }
     }
 
     // データベースのインスタンスや内容を取得するThread

--- a/app/src/main/java/com/example/zaikokanri/MyApplication.java
+++ b/app/src/main/java/com/example/zaikokanri/MyApplication.java
@@ -2,18 +2,37 @@ package com.example.zaikokanri;
 
 import android.app.Application;
 import android.graphics.Bitmap;
+import android.util.Log;
+
+import androidx.room.Room;
+
+import com.example.zaikokanri.db.AppDatabase;
+import com.example.zaikokanri.db.InventoryData;
+import com.example.zaikokanri.db.InventoryDataDao;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class MyApplication extends Application {
 
+    private static final String DATABASE_NAME = "inventory_data";
+
     private static MyApplication instance = new MyApplication();
     private static final List<Bitmap> imageList = new ArrayList<>();
+    private static AppDatabase db;
+    private static InventoryDataDao dao;
+    private static List<InventoryData> inventoryDataList;
 
     @Override
     public void onCreate() {
         super.onCreate();
+        new Thread(() -> {
+            db = Room.databaseBuilder(getApplicationContext(),
+                    AppDatabase.class, DATABASE_NAME).build();
+            dao = db.inventoryDataDao();
+            inventoryDataList = dao.getAll();
+            Log.d("Test", inventoryDataList.toString());
+        }).start();
         instance = this;
     }
 
@@ -42,5 +61,13 @@ public class MyApplication extends Application {
             return false;
         }
         return imageList.get(position) != null;
+    }
+
+    public static List<InventoryData> getInventoryDataList() {
+        return inventoryDataList;
+    }
+
+    public static InventoryDataDao getDao() {
+        return dao;
     }
 }

--- a/app/src/main/java/com/example/zaikokanri/MyApplication.java
+++ b/app/src/main/java/com/example/zaikokanri/MyApplication.java
@@ -67,24 +67,16 @@ public class MyApplication extends Application {
     }
 
     public void initializeDatabase() {
-        final GetDatabaseThread thread = new GetDatabaseThread();
-        thread.start();
-        try {
-            thread.join();
-        } catch (InterruptedException e) {
-            Log.d(TAG_EXCEPTION, e.toString());
-        }
-    }
-
-    // データベースのインスタンスや内容を取得するThread
-    private class GetDatabaseThread extends Thread {
-        @Override
-        public void run() {
-            super.run();
-            db = Room.databaseBuilder(getApplicationContext(),
-                    AppDatabase.class, DATABASE_NAME).build();
-            dao = db.inventoryDataDao();
-            inventoryDataList = dao.getAll();
-        }
+        final OperateInventoryDataTask operateInventoryDataTask = new OperateInventoryDataTask();
+        operateInventoryDataTask.setTask(new OperateInventoryDataTask.ExecuteTask() {
+            @Override
+            public void task() {
+                db = Room.databaseBuilder(getApplicationContext(),
+                        AppDatabase.class, DATABASE_NAME).build();
+                dao = db.inventoryDataDao();
+                inventoryDataList = dao.getAll();
+            }
+        });
+        operateInventoryDataTask.execute();
     }
 }

--- a/app/src/main/java/com/example/zaikokanri/OperateInventoryDataTask.java
+++ b/app/src/main/java/com/example/zaikokanri/OperateInventoryDataTask.java
@@ -1,0 +1,41 @@
+package com.example.zaikokanri;
+
+import android.os.AsyncTask;
+
+import com.example.zaikokanri.db.InventoryData;
+
+public class OperateInventoryDataTask extends AsyncTask<InventoryData, Void, Void> {
+
+    private CallBackTask callBackTask;
+    private ExecuteTask task;
+
+    @Override
+    protected Void doInBackground(final InventoryData... inventoryData) {
+        task.task();
+        return null;
+    }
+
+    @Override
+    protected void onPostExecute(final Void result) {
+        callBackTask.callBack();
+    }
+
+    public void setCallBackTask(CallBackTask callBackTask) {
+        this.callBackTask = callBackTask;
+    }
+
+    public void setTask(final ExecuteTask task) {
+        this.task = task;
+    }
+
+    public abstract static class CallBackTask {
+        public void callBack() {
+        }
+    }
+
+    public static class ExecuteTask {
+        public void task() {
+        }
+    }
+}
+

--- a/app/src/main/java/com/example/zaikokanri/OperateInventoryDataTask.java
+++ b/app/src/main/java/com/example/zaikokanri/OperateInventoryDataTask.java
@@ -17,6 +17,9 @@ public class OperateInventoryDataTask extends AsyncTask<InventoryData, Void, Voi
 
     @Override
     protected void onPostExecute(final Void result) {
+        if (callBackTask == null) {
+            return;
+        }
         callBackTask.callBack();
     }
 

--- a/app/src/main/java/com/example/zaikokanri/db/Converters.java
+++ b/app/src/main/java/com/example/zaikokanri/db/Converters.java
@@ -3,10 +3,8 @@ package com.example.zaikokanri.db;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 
-import androidx.annotation.NonNull;
 import androidx.room.TypeConverter;
 
-import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 import java.sql.Timestamp;
 
@@ -30,7 +28,7 @@ public class Converters {
         bitmap.copyPixelsToBuffer(byteBuffer);
         return byteBuffer.array();
     }
-    
+
     @TypeConverter
     public static Bitmap byteArrayToBitmap(final byte[] bytes) {
         return BitmapFactory.decodeByteArray(bytes, 0, bytes.length);

--- a/app/src/main/java/com/example/zaikokanri/db/InventoryData.java
+++ b/app/src/main/java/com/example/zaikokanri/db/InventoryData.java
@@ -16,11 +16,9 @@ public class InventoryData {
     private static final String TIME_FORMAT_PATTERN = "hh:mm:ss";
 
     @PrimaryKey(autoGenerate = true)
-    @NonNull
     private final int id;
 
     @ColumnInfo(defaultValue = "0")
-    @NonNull
     private final int count;
 
     @ColumnInfo(defaultValue = "NULL")
@@ -30,7 +28,6 @@ public class InventoryData {
     private final Bitmap image;
 
     @ColumnInfo(name = "is_delete", defaultValue = "0")
-    @NonNull
     private final boolean isDelete;
 
     @ColumnInfo(name = "create_at", defaultValue = "CURRENT_TIMESTAMP")
@@ -42,8 +39,8 @@ public class InventoryData {
     private final Timestamp updateAt;
 
     public InventoryData(final int id, final int count, final String comment,
-                         final Bitmap image, final boolean isDelete, final Timestamp createAt,
-                         final Timestamp updateAt) {
+                         final Bitmap image, final boolean isDelete,
+                         @NonNull final Timestamp createAt, @NonNull final Timestamp updateAt) {
         this.id = id;
         this.count = count;
         this.comment = comment;

--- a/app/src/main/java/com/example/zaikokanri/db/InventoryData.java
+++ b/app/src/main/java/com/example/zaikokanri/db/InventoryData.java
@@ -8,35 +8,38 @@ import androidx.room.Entity;
 import androidx.room.PrimaryKey;
 
 import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
 
 @Entity(tableName = "inventory_data")
 public class InventoryData {
 
+    private static final String TIME_FORMAT_PATTERN = "hh:mm:ss";
+
     @PrimaryKey(autoGenerate = true)
     @NonNull
-    public int id;
+    private int id;
 
     @ColumnInfo(defaultValue = "0")
     @NonNull
-    public int count;
+    private int count;
 
     @ColumnInfo(defaultValue = "NULL")
-    public String comment;
+    private String comment;
 
     @ColumnInfo(defaultValue = "NULL", typeAffinity = ColumnInfo.BLOB)
-    public Bitmap image;
+    private Bitmap image;
 
     @ColumnInfo(name = "is_delete", defaultValue = "0")
     @NonNull
-    public boolean isDelete;
+    private boolean isDelete;
 
     @ColumnInfo(name = "create_at", defaultValue = "CURRENT_TIMESTAMP")
     @NonNull
-    public Timestamp createAt;
+    private Timestamp createAt;
 
     @ColumnInfo(name = "update_at", defaultValue = "CURRENT_TIMESTAMP")
     @NonNull
-    public Timestamp updateAt;
+    private Timestamp updateAt;
 
     public InventoryData(final int id, final int count, final String comment,
                          final Bitmap image, final boolean isDelete, final Timestamp createAt,
@@ -48,5 +51,40 @@ public class InventoryData {
         this.isDelete = isDelete;
         this.createAt = createAt;
         this.updateAt = updateAt;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public Bitmap getImage() {
+        return image;
+    }
+
+    public boolean isDelete() {
+        return isDelete;
+    }
+
+    @NonNull
+    public Timestamp getCreateAt() {
+        return createAt;
+    }
+
+    @NonNull
+    public Timestamp getUpdateAt() {
+        return updateAt;
+    }
+
+    public String getCreateAtString() {
+        final SimpleDateFormat simpleDateFormat = new SimpleDateFormat(TIME_FORMAT_PATTERN);
+        return simpleDateFormat.format(createAt);
     }
 }

--- a/app/src/main/java/com/example/zaikokanri/db/InventoryData.java
+++ b/app/src/main/java/com/example/zaikokanri/db/InventoryData.java
@@ -1,5 +1,7 @@
 package com.example.zaikokanri.db;
 
+import android.graphics.Bitmap;
+
 import androidx.annotation.NonNull;
 import androidx.room.ColumnInfo;
 import androidx.room.Entity;
@@ -22,7 +24,7 @@ public class InventoryData {
     public String comment;
 
     @ColumnInfo(defaultValue = "NULL", typeAffinity = ColumnInfo.BLOB)
-    public byte[] image;
+    public Bitmap image;
 
     @ColumnInfo(name = "is_delete", defaultValue = "0")
     @NonNull
@@ -35,4 +37,16 @@ public class InventoryData {
     @ColumnInfo(name = "update_at", defaultValue = "CURRENT_TIMESTAMP")
     @NonNull
     public Timestamp updateAt;
+
+    public InventoryData(final int id, final int count, final String comment,
+                         final Bitmap image, final boolean isDelete, final Timestamp createAt,
+                         final Timestamp updateAt) {
+        this.id = id;
+        this.count = count;
+        this.comment = comment;
+        this.image = image;
+        this.isDelete = isDelete;
+        this.createAt = createAt;
+        this.updateAt = updateAt;
+    }
 }

--- a/app/src/main/java/com/example/zaikokanri/db/InventoryData.java
+++ b/app/src/main/java/com/example/zaikokanri/db/InventoryData.java
@@ -17,29 +17,29 @@ public class InventoryData {
 
     @PrimaryKey(autoGenerate = true)
     @NonNull
-    private int id;
+    private final int id;
 
     @ColumnInfo(defaultValue = "0")
     @NonNull
-    private int count;
+    private final int count;
 
     @ColumnInfo(defaultValue = "NULL")
-    private String comment;
+    private final String comment;
 
     @ColumnInfo(defaultValue = "NULL", typeAffinity = ColumnInfo.BLOB)
-    private Bitmap image;
+    private final Bitmap image;
 
     @ColumnInfo(name = "is_delete", defaultValue = "0")
     @NonNull
-    private boolean isDelete;
+    private final boolean isDelete;
 
     @ColumnInfo(name = "create_at", defaultValue = "CURRENT_TIMESTAMP")
     @NonNull
-    private Timestamp createAt;
+    private final Timestamp createAt;
 
     @ColumnInfo(name = "update_at", defaultValue = "CURRENT_TIMESTAMP")
     @NonNull
-    private Timestamp updateAt;
+    private final Timestamp updateAt;
 
     public InventoryData(final int id, final int count, final String comment,
                          final Bitmap image, final boolean isDelete, final Timestamp createAt,

--- a/app/src/main/java/com/example/zaikokanri/db/InventoryDataDao.java
+++ b/app/src/main/java/com/example/zaikokanri/db/InventoryDataDao.java
@@ -19,4 +19,7 @@ public interface InventoryDataDao {
 
     @Query("DELETE FROM inventory_data WHERE id = (:id)")
     void remove(final int id);
+
+    @Query("DELETE FROM inventory_data")
+    void removeAll();
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,6 @@
     <string name="detail_activity_photo_library_image_button_description">画像を選択</string>
     <string name="detail_activity_save_image_button_description">保存</string>
     <string name="detail_activity_delete_image_button_description">削除</string>
-    <string name="progress_dialog_title">データ追加中</string>
-    <string name="progress_dialog_message">データを追加しています。少々お待ちください。</string>
+    <string name="progress_dialog_title_add">データ追加中</string>
+    <string name="progress_dialog_message_add">データを追加しています。少々お待ちください。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,6 @@
     <string name="detail_activity_photo_library_image_button_description">画像を選択</string>
     <string name="detail_activity_save_image_button_description">保存</string>
     <string name="detail_activity_delete_image_button_description">削除</string>
-    <string name="progress_dialog_title">データ処理中</string>
-    <string name="progress_dialog_message">データを処理しています。少々お待ちください。</string>
+    <string name="progress_dialog_title">データ追加中</string>
+    <string name="progress_dialog_message">データを追加しています。少々お待ちください。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,4 +19,6 @@
     <string name="detail_activity_photo_library_image_button_description">画像を選択</string>
     <string name="detail_activity_save_image_button_description">保存</string>
     <string name="detail_activity_delete_image_button_description">削除</string>
+    <string name="progress_dialog_title">データ処理中</string>
+    <string name="progress_dialog_message">データを処理しています。少々お待ちください。</string>
 </resources>


### PR DESCRIPTION
## チケットURL
https://github.com/freemake-morikawa/zaikokanri/pull/39

## 対応内容・対応背景・妥協点
- `MyApplication`クラスにdaoインスタンスとDBのリストを保持
- 追加ボタン押下時にDBにデータを追加する処理を実装
- `InventoryData`クラスの修正

## やったこと
- `MyApplication`クラスにdaoインスタンスとDBのリストをメンバ変数として保持させる
	新規スレッドを作り、`InventoryDataDao#getAll()`を行う
- 追加ボタン押下時にDBにデータを追加する処理を実装
	こちらも新規スレッドを作り、`InventoryDataDao#add()`を行う
- `InventoryData`クラスのメンバ変数をpublic -> private finalに変更
- `InventoryData`クラスのコンストラクタを作成
- `InventoryData`クラスのゲッターを作成
- `InventoryData`クラスに`getCreateAtString()`を作成
	いずれ使う作成時間を文字列で返す関数

## UI:before/after
UIに変化はなし
DBにデータが登録されていることは確認

<img width="823" alt="DB" src="https://user-images.githubusercontent.com/115610835/210908499-658956ea-51ce-46e1-a718-bde824c8a5fe.png">

## テスト
- 数量やコメントを変更してデータを追加 -> DBに格納されていることを確認