### PR TITLE
起動時にDBのデータを表示する

### DIFF
--- a/app/src/main/java/com/example/zaikokanri/MainActivity.java
+++ b/app/src/main/java/com/example/zaikokanri/MainActivity.java
@@ -131,10 +131,20 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         // 時計の処理のためViewを取得
         clockTextView = findViewById(R.id.clock_text_view);
 
-        // リスト追加
+        // 初回リスト表示
         final ListView listView = findViewById(R.id.inventory_info_list_view);
         adapter = new InventoryInfoListViewAdapter(this, R.layout.list_item, this);
+        for (InventoryData inventoryData : MyApplication.getInstance().getInventoryDataList()) {
+            final InventoryInfo inventoryInfo = new InventoryInfo(
+                    inventoryData.getCreateAtString(),
+                    String.valueOf(inventoryData.getCount()),
+                    inventoryData.getComment()
+            );
+            adapter.add(inventoryInfo);
+        }
+        listView.setAdapter(adapter);
 
+        // リストアイテム追加
         final Button addInventoryInfoButton = findViewById(R.id.add_inventory_info_button);
         addInventoryInfoButton.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -154,7 +164,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                 final InventoryData inventoryData = new InventoryData(
                         0, Integer.parseInt(inventoryCountTextView.getText().toString()),
                         commentEditText.getText().toString(),
-                        null, true, timestamp, timestamp);
+                        null, false, timestamp, timestamp);
 
                 final OperateInventoryDataTask operateInventoryDataTask =
                         new OperateInventoryDataTask();
@@ -172,6 +182,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                     @Override
                     public void task() {
                         MyApplication.getInstance().getDao().add(inventoryData);
+                        MyApplication.getInstance().getInventoryDataList().add(inventoryData);
                     }
                 });
                 operateInventoryDataTask.execute(inventoryData);

--- a/app/src/main/java/com/example/zaikokanri/MyApplication.java
+++ b/app/src/main/java/com/example/zaikokanri/MyApplication.java
@@ -2,7 +2,6 @@ package com.example.zaikokanri;
 
 import android.app.Application;
 import android.graphics.Bitmap;
-import android.util.Log;
 
 import androidx.room.Room;
 

--- a/app/src/main/java/com/example/zaikokanri/db/Converters.java
+++ b/app/src/main/java/com/example/zaikokanri/db/Converters.java
@@ -31,6 +31,9 @@ public class Converters {
 
     @TypeConverter
     public static Bitmap byteArrayToBitmap(final byte[] bytes) {
+        if (bytes == null) {
+            return null;
+        }
         return BitmapFactory.decodeByteArray(bytes, 0, bytes.length);
     }
 }


### PR DESCRIPTION
## チケットURL
https://github.com/freemake-morikawa/zaikokanri/pull/40

## 対応内容・対応背景・妥協点

- `ActivityMain#initView`にて起動時に`MyApplication.InveotryDataLits`内のデータを全てadapterに反映させ、表示させる
- データ追加時にdelete_flagがtrueになっており、全データ削除済と判定されていたため、falseに変更
- `dao.getAll`がimageのNullPointerExeptionを起こすことがあったので、ConverterにNullチェックを追加

## やったこと

## UI before/after

動画が重すぎたのでGithubに載せるのは断念（涙）

## テスト

- 数種類のデータを追加 -> アプリ終了 -> アプリ起動　OK
- 数種類のデータを追加 -> ビルド -> アプリ起動 OK