### PR TITLE
DBのimage:Bitmapをuri:URIに変更

### DIFF
--- a/app/src/main/java/com/example/zaikokanri/db/AppDatabase.java
+++ b/app/src/main/java/com/example/zaikokanri/db/AppDatabase.java
@@ -4,7 +4,8 @@ import androidx.room.Database;
 import androidx.room.RoomDatabase;
 import androidx.room.TypeConverters;
 
-@Database(entities = {InventoryData.class}, version = 1, exportSchema = false)
+
+@Database(entities = {InventoryData.class}, version = 2, exportSchema = false)
 @TypeConverters({Converters.class})
 public abstract class AppDatabase extends RoomDatabase {
     public abstract InventoryDataDao inventoryDataDao();

--- a/app/src/main/java/com/example/zaikokanri/db/Converters.java
+++ b/app/src/main/java/com/example/zaikokanri/db/Converters.java
@@ -19,6 +19,9 @@ public class Converters {
 
     @TypeConverter
     public static Uri stringToUri(final String string) {
+        if (string == null) {
+            return null;
+        }
         return Uri.parse(string);
     }
 

--- a/app/src/main/java/com/example/zaikokanri/db/Converters.java
+++ b/app/src/main/java/com/example/zaikokanri/db/Converters.java
@@ -1,11 +1,9 @@
 package com.example.zaikokanri.db;
 
-import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
+import android.net.Uri;
 
 import androidx.room.TypeConverter;
 
-import java.nio.ByteBuffer;
 import java.sql.Timestamp;
 
 public class Converters {
@@ -20,17 +18,15 @@ public class Converters {
     }
 
     @TypeConverter
-    public static byte[] bitmapToByteArray(final Bitmap bitmap) {
-        if (bitmap == null) {
-            return null;
-        }
-        ByteBuffer byteBuffer = ByteBuffer.allocate(bitmap.getByteCount());
-        bitmap.copyPixelsToBuffer(byteBuffer);
-        return byteBuffer.array();
+    public static Uri stringToUri(final String string) {
+        return Uri.parse(string);
     }
 
     @TypeConverter
-    public static Bitmap byteArrayToBitmap(final byte[] bytes) {
-        return BitmapFactory.decodeByteArray(bytes, 0, bytes.length);
+    public static String uriToString(final Uri uri) {
+        if (uri == null) {
+            return null;
+        }
+        return uri.toString();
     }
 }

--- a/app/src/main/java/com/example/zaikokanri/db/InventoryData.java
+++ b/app/src/main/java/com/example/zaikokanri/db/InventoryData.java
@@ -1,6 +1,6 @@
 package com.example.zaikokanri.db;
 
-import android.graphics.Bitmap;
+import android.net.Uri;
 
 import androidx.annotation.NonNull;
 import androidx.room.ColumnInfo;
@@ -24,8 +24,8 @@ public class InventoryData {
     @ColumnInfo(defaultValue = "NULL")
     private final String comment;
 
-    @ColumnInfo(defaultValue = "NULL", typeAffinity = ColumnInfo.BLOB)
-    private final Bitmap image;
+    @ColumnInfo(defaultValue = "NULL")
+    private final Uri uri;
 
     @ColumnInfo(name = "is_delete", defaultValue = "0")
     private final boolean isDelete;
@@ -39,12 +39,12 @@ public class InventoryData {
     private final Timestamp updateAt;
 
     public InventoryData(final int id, final int count, final String comment,
-                         final Bitmap image, final boolean isDelete,
+                         final Uri uri, final boolean isDelete,
                          @NonNull final Timestamp createAt, @NonNull final Timestamp updateAt) {
         this.id = id;
         this.count = count;
         this.comment = comment;
-        this.image = image;
+        this.uri = uri;
         this.isDelete = isDelete;
         this.createAt = createAt;
         this.updateAt = updateAt;
@@ -62,8 +62,8 @@ public class InventoryData {
         return comment;
     }
 
-    public Bitmap getImage() {
-        return image;
+    public Uri getUri() {
+        return uri;
     }
 
     public boolean isDelete() {


### PR DESCRIPTION
# チケットURL
https://github.com/freemake-morikawa/zaikokanri/pull/41

# 対応内容・対応背景・妥協点
リストをなくしDB管理のみに変更しようとしていた際に、画像データの取り扱いにてDB管理だとサイズが大きすぎて保存することができなかった
そのため、Bitmap->BLOBではなく、Uri->STRINGとして保存する方法に変更

# やったこと
- 現在のDBを削除 -> 新しいDBと変更するミグレーションを実行
- ConvertersにURI<->STRINGを追加

# やっていないこと

# UI:before/after
- UIに変化なし

# テスト
- 起動 -> データ追加ができることを確認
- 詳細な動作確認はデータ追加処理などを今後見ていく